### PR TITLE
chore: add GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,52 @@
+name: "Bug Report"
+description: "Report a defect or regression"
+title: "[Bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping us improve Neo4j GraphRAG! Please provide as much context as possible.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened? What did you expect instead?
+      placeholder: Clear and concise description of the issue
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps To Reproduce
+      description: List the minimal steps required to reproduce the bug.
+      placeholder: |
+        1. …
+        2. …
+        3. …
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Runtime details (OS, Python version, GraphRAG version, etc.)
+      placeholder: |
+        - OS:
+        - Python:
+        - GraphRAG version:
+        - Additional context:
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs & Diagnostics
+      description: Paste relevant stack traces or attach diagnostics outputs (`artifacts/environment/versions.json`, CLI logs, etc.).
+      render: shell
+  - type: textarea
+    id: mitigation
+    attributes:
+      label: Proposed Mitigation / Workaround
+      description: Optional ideas for fixing or mitigating the issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Neo4j GraphRAG Support Discussions
-    url: https://github.com/DrJLabs/FancyRAG/discussions
+    url: https://github.com/neo4j/graphrag/discussions
     about: Ask questions, share ideas, or get help from the community.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Neo4j GraphRAG Support Discussions
+    url: https://github.com/DrJLabs/FancyRAG/discussions
+    about: Ask questions, share ideas, or get help from the community.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: "Feature Request"
+description: "Suggest an enhancement or new capability"
+title: "[Feature] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea that will improve Neo4j GraphRAG? Let us know!
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Provide a concise description of the proposed feature.
+      placeholder: Describe the problem and the desired outcome.
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why do we need this feature? Who benefits from it?
+    validations:
+      required: true
+  - type: textarea
+    id: requirements
+    attributes:
+      label: Requirements & Acceptance Criteria
+      description: List specific requirements, user stories, or acceptance criteria.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Share any alternative solutions or workarounds you have evaluated.
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Screenshots, diagrams, references, or links.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+- [ ] Fixes # (issue)
+- [ ] Related # (issue)
+
+Provide a short description of the change and its motivation.
+
+## Testing
+- [ ] Not required (explain why)
+- [ ] `pytest`
+- [ ] Other (specify)
+
+## Checklist
+- [ ] Code follows project coding standards
+- [ ] Tests added/updated and pass locally
+- [ ] Docs updated (README, architecture, story, etc.)
+- [ ] QA artifacts (risk, test design, trace, NFR, gate) updated if required

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 - [ ] Fixes # (issue)
 - [ ] Related # (issue)
 
-Provide a short description of the change and its motivation.
+<!-- Provide a short description of the change and its motivation. -->
 
 ## Testing
 - [ ] Not required (explain why)


### PR DESCRIPTION
## Summary
- add bug and feature issue templates with required fields and disable blank submissions
- add default pull request template to capture testing and QA checklist

## Testing
- not required (templates only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added guided templates for bug reports and feature requests to standardize submissions.
  - Introduced a pull request template with sections for Summary, Testing, and Checklist.
  - Added a contact link to community support discussions for questions and ideas.

- Chores
  - Disabled opening blank issues to encourage use of structured templates.
  - Configured repository settings to streamline contribution workflows and improve issue quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->