### PR TITLE
fix: install Prometheus client during bootstrap

### DIFF
--- a/docs/stories/2.2.openai-readiness-probe.md
+++ b/docs/stories/2.2.openai-readiness-probe.md
@@ -1,7 +1,7 @@
 # Story 2.2: OpenAI Readiness Probe CLI
 
 ## Status
-Ready for Review
+Done
 
 ## Story
 **As a** GraphRAG platform operator,
@@ -82,6 +82,7 @@ Ready for Review
 | Date       | Version | Description                             | Author |
 |------------|---------|-----------------------------------------|--------|
 | 2025-09-25 | 0.1     | Initial draft of Story 2.2 created      | Bob    |
+| 2025-09-26 | 1.0     | Bootstrap now installs probe telemetry dependency; story marked done | James  |
 
 ## Dev Agent Record
 ### Agent Model Used
@@ -90,11 +91,13 @@ Ready for Review
 ### Debug Log References
 - `pytest tests/unit/cli/test_sanitizer.py tests/unit/cli/test_telemetry.py tests/unit/cli/test_openai_probe.py tests/unit/cli/test_diagnostics.py`
 - `pytest tests/integration/cli/test_openai_probe_cli.py`
+- `pytest tests/integration/test_openai_telemetry.py -q`
 
 ### Completion Notes List
 - Implemented OpenAI readiness probe CLI subcommand with sanitized reporting, exponential backoff, and metrics export.
 - Centralized redaction helpers in `src/cli/sanitizer.py` and updated telemetry buckets (100 ms–5 s) to satisfy SLO alignment.
 - Documented probe workflow/setup in `docs/architecture/overview.md` and added unit/integration pytest coverage for success, fallback, rate-limit, redaction, and metrics scenarios.
+- Ensured `scripts/bootstrap.sh` installs `prometheus-client` so telemetry metrics tests run in cloud bootstrap environments.
 
 ### File List
 - src/cli/diagnostics.py
@@ -108,6 +111,7 @@ Ready for Review
 - tests/unit/cli/test_openai_probe.py
 - tests/integration/cli/test_openai_probe_cli.py
 - tests/unit/cli/test_diagnostics.py
+- scripts/bootstrap.sh
 
 ## QA Results
 ### Risk Profile

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -13,10 +13,10 @@ ASSUME_PY312="${BOOTSTRAP_ASSUME_PY312:-0}"
 PACKAGES=(
   "neo4j-graphrag[openai,qdrant]"
   "neo4j>=5,<6"
-  "qdrant-client>=1.10"
   "openai>=1,<2"
-  "structlog>=24,<25"
   "prometheus-client>=0.23,<1"
+  "qdrant-client>=1.10"
+  "structlog>=24,<25"
   "pytest>=8,<9"
 )
 TEST_LOCK_CONTENT=$(cat <<'EOF'

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -23,10 +23,10 @@ TEST_LOCK_CONTENT=$(cat <<'EOF'
 # Generated in test mode (no packages installed)
 neo4j-graphrag==0.9.0
 neo4j==5.23.0
-qdrant-client==1.10.4
 openai==1.40.3
-structlog==24.1.0
 prometheus-client==0.23.1
+qdrant-client==1.10.4
+structlog==24.1.0
 pytest==8.3.2
 EOF
 )

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -16,6 +16,7 @@ PACKAGES=(
   "qdrant-client>=1.10"
   "openai>=1,<2"
   "structlog>=24,<25"
+  "prometheus-client>=0.23,<1"
   "pytest>=8,<9"
 )
 TEST_LOCK_CONTENT=$(cat <<'EOF'

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -26,6 +26,7 @@ neo4j==5.23.0
 qdrant-client==1.10.4
 openai==1.40.3
 structlog==24.1.0
+prometheus-client==0.23.1
 pytest==8.3.2
 EOF
 )


### PR DESCRIPTION
## Summary
- ensure `scripts/bootstrap.sh` installs `prometheus-client` so OpenAI telemetry tests work in provisioned environments
- mark Story 2.2 as Done and log the dependency update in the story change log/dev notes

## Testing
- PYTHONPATH=src .venv/bin/python -m pytest tests/integration/test_openai_telemetry.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated OpenAI readiness probe guide with current status, CLI details, telemetry coverage, and integration test references.
  - Clarified developer records and artifacts list related to test tooling.

- Chores
  - Added a telemetry client dependency to the installation process to ensure availability during runtime and tests.
  - Updated lockfile to include the new dependency and version constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->