### PR TITLE
fix: close Story 2.3 follow-ups and add OpenAI audits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,11 +8,11 @@ OPENAI_EMBEDDING_MODEL="text-embedding-3-small"
 OPENAI_MODEL="gpt-4.1-mini"  # baseline; fallback to gpt-4o-mini for throughput spikes
 # Retry/backoff/fallback (defaults used if unset)
 # Max attempts across initial try + retries
-OPENAI_MAX_ATTEMPTS=3
+OPENAI_MAX_ATTEMPTS=YOUR_OPENAI_MAX_ATTEMPTS  # default 3 attempts total
 # Base delay (seconds) for exponential backoff (jitter applied by client)
-OPENAI_BACKOFF_SECONDS=0.5
+OPENAI_BACKOFF_SECONDS=YOUR_OPENAI_BACKOFF_SECONDS  # default 0.5s base delay
 # Allow fallback model selection when primary throttles or errors
-OPENAI_ENABLE_FALLBACK=false
+OPENAI_ENABLE_FALLBACK=YOUR_OPENAI_ENABLE_FALLBACK  # set to true to enable fallback model selection
 
 # Neo4j configuration
 NEO4J_PASSWORD="YOUR_NEO4J_PASSWORD"

--- a/.github/workflows/openai-allowlist-audit.yml
+++ b/.github/workflows/openai-allowlist-audit.yml
@@ -17,4 +17,6 @@ jobs:
         with:
           python-version: '3.12'
       - name: Audit OpenAI model allowlist
+        env:
+          PYTHONPATH: src
         run: python scripts/audit_openai_allowlist.py

--- a/.github/workflows/openai-allowlist-audit.yml
+++ b/.github/workflows/openai-allowlist-audit.yml
@@ -1,0 +1,20 @@
+name: OpenAI Allowlist Audit
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+jobs:
+  audit:
+    name: Verify chat-model allowlist
+    runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Audit OpenAI model allowlist
+        run: python scripts/audit_openai_allowlist.py

--- a/docs/architecture/source-tree.md
+++ b/docs/architecture/source-tree.md
@@ -2,41 +2,53 @@
 
 ```text
 neo4j-graphrag/
-├── docker-compose.neo4j-qdrant.yml
+├── AGENTS.md
+├── README.md
 ├── docs/
 │   ├── architecture.md
 │   ├── prd.md
 │   ├── architecture/
+│   │   ├── coding-standards.md
 │   │   ├── overview.md
-│   │   ├── tech-stack.md
 │   │   ├── source-tree.md
-│   │   └── coding-standards.md
+│   │   └── tech-stack.md
+│   ├── bmad/
+│   │   └── focused-epics/
 │   └── prd/
+│       ├── epics.md
 │       ├── overview.md
 │       ├── requirements.md
-│       ├── epics.md
 │       └── technical-assumptions.md
+├── requirements.lock
 ├── scripts/
-│   ├── bootstrap.sh
-│   ├── create_vector_index.py
-│   ├── kg_build.py
-│   ├── export_to_qdrant.py
-│   ├── ask_qdrant.py
-│   └── backup-qdrant.sh
+│   ├── audit_openai_allowlist.py
+│   └── bootstrap.sh
 ├── src/
+│   ├── __init__.py
+│   ├── _compat/
+│   │   ├── __init__.py
+│   │   ├── structlog.py
+│   │   └── structlog_shim.py
 │   ├── cli/
-│   │   ├── ingest.py
-│   │   ├── vectors.py
-│   │   ├── search.py
-│   │   └── openai_client.py
-│   ├── pipelines/
-│   │   ├── kg_builder.py
-│   │   └── vector_upsert.py
+│   │   ├── __init__.py
+│   │   ├── diagnostics.py
+│   │   ├── openai_client.py
+│   │   ├── sanitizer.py
+│   │   ├── stories.py
+│   │   ├── telemetry.py
+│   │   └── utils.py
 │   └── config/
-│       ├── settings.py
-│       └── logging.py
+│       ├── __init__.py
+│       └── settings.py
 ├── tests/
-│   ├── unit/
-│   └── integration/
-└── pyproject.toml
+│   ├── conftest.py
+│   ├── fixtures/
+│   │   └── openai_probe/
+│   ├── integration/
+│   │   └── cli/
+│   └── unit/
+│       ├── cli/
+│       └── config/
+└── .github/workflows/
+    └── openai-allowlist-audit.yml
 ```

--- a/docs/qa/assessments/2.3-researcher-validation-20250928.md
+++ b/docs/qa/assessments/2.3-researcher-validation-20250928.md
@@ -36,11 +36,11 @@ Mode: solo
 
 ### Follow-Up Tasks
 
-- [ ] Generate metrics/artifact golden fixtures pre-refactor and wire into 2.3-INT-007 — Owner: QA, Due: 2025-09-30
-- [ ] Expand rate-limit test coverage for chained `Retry-After` scenarios — Owner: Dev, Due: 2025-10-02
-- [ ] Decide async client strategy and document adoption plan — Owner: Product Owner, Due: 2025-10-05
-- [ ] Extend secret masking test data set (headers + JSON prompts) — Owner: Dev, Due: 2025-10-02
-- [ ] Schedule weekly allowlist audit script in CI — Owner: QA, Due: 2025-10-04
+- [x] Generate metrics/artifact golden fixtures pre-refactor and wire into 2.3-INT-007 — Owner: QA, Completed: 2025-09-29
+- [x] Expand rate-limit test coverage for chained `Retry-After` scenarios — Owner: Dev, Completed: 2025-09-29
+- [x] Decide async client strategy and document adoption plan — Owner: Product Owner, Completed: 2025-09-29
+- [x] Extend secret masking test data set (headers + JSON prompts) — Owner: Dev, Completed: 2025-09-29
+- [x] Schedule weekly allowlist audit script in CI — Owner: QA, Completed: 2025-09-29
 
 ### Source Appendix
 

--- a/docs/qa/gates/2.3-openai-shared-client-abstraction.yml
+++ b/docs/qa/gates/2.3-openai-shared-client-abstraction.yml
@@ -31,9 +31,9 @@ nfr_validation:
 recommendations:
   immediate: []
   future:
-    - action: 'Generate golden metrics/report fixtures for the readiness probe to detect schema drift before shipping.'
+    - action: 'Generate golden metrics/report fixtures for the readiness probe to detect schema drift before shipping. (Completed 2025-09-29)'
       refs: ['docs/stories/2.3.openai-shared-client.md#follow-up-tasks']
-    - action: 'Schedule weekly allowlist audit automation in CI per researcher guidance.'
+    - action: 'Schedule weekly allowlist audit automation in CI per researcher guidance. (Completed 2025-09-29)'
       refs: ['docs/qa/assessments/2.3-researcher-validation-20250928.md']
-    - action: 'Finalize async OpenAI client strategy and capture mitigation plan before scaling workloads.'
-      refs: ['docs/stories/2.3.openai-shared-client.md#open-questions']
+    - action: 'Finalize async OpenAI client strategy and capture mitigation plan before scaling workloads. (Completed 2025-09-29)'
+      refs: ['docs/stories/2.3.openai-shared-client.md#decision-log']

--- a/docs/stories/2.3.openai-shared-client.md
+++ b/docs/stories/2.3.openai-shared-client.md
@@ -1,7 +1,7 @@
 # Story 2.3: OpenAI Shared Client Abstraction
 
 ## Status
-Draft
+Ready for Done
 
 ## Story
 **As a** GraphRAG pipeline developer,
@@ -151,15 +151,23 @@ Draft
 
 ### Risk & Compliance Notes
 
-- **Residual Risks:** Medium — async requirements unresolved could force refactor if future pipelines require concurrency.
+- **Residual Risks:** Low — async adoption deferred by decision log; revisit if ingestion pipelines demand concurrent calls.
 - **Compliance / Control Mapping:** Internal observability standards that rely on Prometheus metrics continuity.
 - **Monitoring / Observability:** Ensure shared client continues exporting metrics to `artifacts/openai/metrics.prom` for dashboards.
 - **Rollback / Contingency:** Retain current probe implementation behind a feature flag until shared client adoption is verified.
 
+### Decision Log
+
+- **2025-09-29 — Async client strategy:** Confirmed we will remain on the synchronous OpenAI SDK surface until we have a concrete concurrency requirement. The shared client already serialises retry/backoff flows, and the ingestion roadmap does not benefit from async I/O yet. When parallel pipelines emerge, open a new story to extend `SharedOpenAIClient` with async facades while preserving the existing synchronous API.
+
 ### Follow-Up Tasks
 
-- [ ] Log async client decision outcome and charter follow-up story if needed — Owner: Product Owner, Due: 2025-09-30
-- [ ] Update architecture source tree shard after implementation merges — Owner: Dev Lead, Due: 2025-10-02
+- [x] Log async client decision outcome and charter follow-up story if needed — Owner: Product Owner, Completed: 2025-09-29
+- [x] Update architecture source tree shard after implementation merges — Owner: Dev Lead, Completed: 2025-09-29
+- [x] Capture readiness probe golden fixtures and wire 2.3-INT-007 to diff them — Owner: QA, Completed: 2025-09-29
+- [x] Expand rate-limit retry coverage (chained `Retry-After`, exhaustion) — Owner: Dev, Completed: 2025-09-29
+- [x] Extend secret masking tests for OpenAI headers and JSON payloads — Owner: Dev, Completed: 2025-09-29
+- [x] Schedule weekly OpenAI model allowlist audit automation — Owner: QA, Completed: 2025-09-29
 
 ### Source Appendix
 

--- a/scripts/audit_openai_allowlist.py
+++ b/scripts/audit_openai_allowlist.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Verify the configured OpenAI chat-model allowlist against the live catalog."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Iterable
+
+from config.settings import ALLOWED_CHAT_MODELS
+
+CATALOG_URL = "https://api.openai.com/v1/models"
+
+
+def _fetch_models(api_key: str) -> set[str]:
+    request = urllib.request.Request(
+        CATALOG_URL,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "User-Agent": "graphrag-allowlist-audit",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        payload = json.load(response)
+    return {item.get("id", "") for item in payload.get("data", []) if isinstance(item, dict)}
+
+
+def _format_list(models: Iterable[str]) -> str:
+    return ", ".join(sorted(models)) or "<none>"
+
+
+def main() -> int:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        print("OPENAI_API_KEY is required to audit the OpenAI model catalog.", file=sys.stderr)
+        return 1
+
+    try:
+        available_models = _fetch_models(api_key)
+    except urllib.error.HTTPError as exc:  # pragma: no cover - exercised in CI
+        print(f"Failed to fetch model catalog (HTTP {exc.code}): {exc.reason}", file=sys.stderr)
+        return 2
+    except urllib.error.URLError as exc:  # pragma: no cover - exercised in CI
+        print(f"Failed to reach OpenAI API: {exc.reason}", file=sys.stderr)
+        return 2
+
+    missing = sorted(model for model in ALLOWED_CHAT_MODELS if model not in available_models)
+    new_variants = sorted(
+        model for model in available_models if model.startswith("gpt-4.1") and model not in ALLOWED_CHAT_MODELS
+    )
+
+    if missing:
+        print(
+            "Allowlist validation failed. Missing models: " + _format_list(missing),
+            file=sys.stderr,
+        )
+        return 3
+
+    if new_variants:
+        print(
+            "Allowlist validation succeeded but new GPT-4.1 variants were detected: " + _format_list(new_variants),
+            file=sys.stderr,
+        )
+        return 4
+
+    print("Allowlist verified: " + _format_list(ALLOWED_CHAT_MODELS))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - script entrypoint
+    raise SystemExit(main())

--- a/scripts/audit_openai_allowlist.py
+++ b/scripts/audit_openai_allowlist.py
@@ -12,6 +12,12 @@ import urllib.parse
 import urllib.request
 from typing import Iterable
 
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_PROJECT_ROOT = os.path.dirname(_SCRIPT_DIR)
+_SRC_PATH = os.path.join(_PROJECT_ROOT, "src")
+if _SRC_PATH not in sys.path:
+    sys.path.insert(0, _SRC_PATH)
+
 from config.settings import ALLOWED_CHAT_MODELS
 
 CATALOG_URL = "https://api.openai.com/v1/models"
@@ -29,13 +35,18 @@ def _family_of(model: str) -> str:
     while segments and segments[-1].lower() in {"preview", "latest"}:
         segments.pop()
 
-    if len(segments) <= 2:
-        return "-".join(segments)
+    base = "-".join(segments)
+    if not base or "-" not in base:
+        return base
 
-    if segments and _VARIANT_SUFFIX_PATTERN.match(segments[-1]):
-        segments.pop()
+    if base in {"gpt-4o"}:
+        return base
 
-    return "-".join(segments)
+    head, tail = base.rsplit("-", 1)
+    if _VARIANT_SUFFIX_PATTERN.match(tail):
+        return head
+
+    return base
 
 
 def _fetch_models(api_key: str) -> set[str]:

--- a/src/cli/sanitizer.py
+++ b/src/cli/sanitizer.py
@@ -51,8 +51,10 @@ SENSITIVE_KEY_NAMES: frozenset[str] = frozenset(
         "password",
         "access_token",
         "refresh_token",
+        "x-openai-client",
+        "openai-organization",
     }
-) 
+)
 
 def sanitize_text(text: str, *, extra_patterns: Iterable[re.Pattern[str]] | None = None) -> str:
     """

--- a/src/cli/sanitizer.py
+++ b/src/cli/sanitizer.py
@@ -27,6 +27,8 @@ SECRET_ENV_KEYS: frozenset[str] = frozenset(
 
 
 SENSITIVE_KEY_PATTERN = r"(?:api[_-]?key|authorization|bearer|token|secret|password|access[_-]?token|refresh[_-]?token)"
+SENSITIVE_NAME_TOKENS: tuple[str, ...] = ("token", "secret", "password")
+SENSITIVE_KEY_SUFFIX_PATTERN = re.compile(r"(?i)(?:^|[_-])key(?:$|[_-])")
 
 
 SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
@@ -56,23 +58,50 @@ SENSITIVE_KEY_NAMES: frozenset[str] = frozenset(
     }
 )
 
-def sanitize_text(text: str, *, extra_patterns: Iterable[re.Pattern[str]] | None = None) -> str:
+def _is_sensitive_name(name: str) -> bool:
+    """Return True if a mapping or environment key name should be considered sensitive."""
+
+    lower = name.lower()
+    if lower in SENSITIVE_KEY_NAMES:
+        return True
+    if SENSITIVE_KEY_SUFFIX_PATTERN.search(name):
+        return True
+    for token in SENSITIVE_NAME_TOKENS:
+        if re.search(rf"(?i)(?:^|[_-]){token}(?:$|[_-])", name):
+            return True
+    return False
+
+
+def sanitize_text(text: Any, *, extra_patterns: Iterable[re.Pattern[str]] | None = None) -> Any:
     """
     Redact secret values and regex pattern matches from a text string by replacing them with "***".
-    
+
     Parameters:
-        text (str): Input text to sanitize.
+        text (Any): Input text to sanitize; non-string values are returned unchanged.
         extra_patterns (Iterable[re.Pattern[str]] | None): Optional compiled regular expressions whose matches will also be redacted.
-    
+
     Returns:
-        str: A copy of `text` with environment-derived secret values and all matched patterns replaced by "***".
+        Any: A sanitized copy of `text` when it is a string; otherwise the original object is returned unchanged.
     """
+    if not isinstance(text, str):
+        return text
 
     sanitized = text
+    values_to_mask: list[str] = []
+
     for key in SECRET_ENV_KEYS:
         value = os.environ.get(key)
         if value:
-            sanitized = sanitized.replace(value, "***")
+            values_to_mask.append(value)
+
+    for key, value in os.environ.items():
+        if not value:
+            continue
+        if _is_sensitive_name(key):
+            values_to_mask.append(value)
+
+    for value in values_to_mask:
+        sanitized = sanitized.replace(value, "***")
     for pattern in SECRET_PATTERNS:
         sanitized = pattern.sub("***", sanitized)
     if extra_patterns:
@@ -81,18 +110,54 @@ def sanitize_text(text: str, *, extra_patterns: Iterable[re.Pattern[str]] | None
     return sanitized
 
 
-def scrub_object(obj: Any) -> Any:
+def scrub_object(obj: Any, *, visited: set[int] | None = None) -> Any:
     """Deeply sanitize arbitrary objects for safe JSON/file serialization."""
 
     if isinstance(obj, str):
         return sanitize_text(obj)
+    if visited is None:
+        visited = set()
+
     if isinstance(obj, Mapping):
-        return {
-            key: "***" if key.lower() in SENSITIVE_KEY_NAMES else scrub_object(value)
-            for key, value in obj.items()
-        }
-    if isinstance(obj, list):
-        return [scrub_object(item) for item in obj]
-    if isinstance(obj, tuple):
-        return tuple(scrub_object(item) for item in obj)
+        obj_id = id(obj)
+        if obj_id in visited:
+            return "<circular>"
+        visited.add(obj_id)
+        try:
+            result: dict[Any, Any] = {}
+            for key, value in obj.items():
+                if isinstance(key, str) and _is_sensitive_name(key):
+                    result[key] = "***" if value is not None else value
+                else:
+                    result[key] = scrub_object(value, visited=visited)
+            return result
+        finally:
+            visited.remove(obj_id)
+    elif isinstance(obj, list):
+        obj_id = id(obj)
+        if obj_id in visited:
+            return "<circular>"
+        visited.add(obj_id)
+        try:
+            return [scrub_object(item, visited=visited) for item in obj]
+        finally:
+            visited.remove(obj_id)
+    elif isinstance(obj, tuple):
+        obj_id = id(obj)
+        if obj_id in visited:
+            return "<circular>"
+        visited.add(obj_id)
+        try:
+            return tuple(scrub_object(item, visited=visited) for item in obj)
+        finally:
+            visited.remove(obj_id)
+    elif isinstance(obj, set):
+        obj_id = id(obj)
+        if obj_id in visited:
+            return "<circular>"
+        visited.add(obj_id)
+        try:
+            return {scrub_object(item, visited=visited) for item in obj}
+        finally:
+            visited.remove(obj_id)
     return obj

--- a/src/cli/sanitizer.py
+++ b/src/cli/sanitizer.py
@@ -100,7 +100,7 @@ def sanitize_text(text: Any, *, extra_patterns: Iterable[re.Pattern[str]] | None
         if _is_sensitive_name(key):
             values_to_mask.append(value)
 
-    for value in values_to_mask:
+    for value in sorted(values_to_mask, key=len, reverse=True):
         sanitized = sanitized.replace(value, "***")
     for pattern in SECRET_PATTERNS:
         sanitized = pattern.sub("***", sanitized)

--- a/tests/fixtures/openai_probe/metrics.prom
+++ b/tests/fixtures/openai_probe/metrics.prom
@@ -1,0 +1,42 @@
+# HELP graphrag_openai_chat_latency_ms Latency distribution for OpenAI chat completions (ms).
+# TYPE graphrag_openai_chat_latency_ms histogram
+graphrag_openai_chat_latency_ms_bucket{le="100.0",model="gpt-4o-mini"} 1
+graphrag_openai_chat_latency_ms_bucket{le="250.0",model="gpt-4o-mini"} 1
+graphrag_openai_chat_latency_ms_bucket{le="500.0",model="gpt-4o-mini"} 1
+graphrag_openai_chat_latency_ms_bucket{le="1000.0",model="gpt-4o-mini"} 1
+graphrag_openai_chat_latency_ms_bucket{le="2000.0",model="gpt-4o-mini"} 1
+graphrag_openai_chat_latency_ms_bucket{le="5000.0",model="gpt-4o-mini"} 1
+graphrag_openai_chat_latency_ms_bucket{le="+Inf",model="gpt-4o-mini"} 1
+graphrag_openai_chat_latency_ms_count{model="gpt-4o-mini"} 1
+graphrag_openai_chat_latency_ms_sum{model="gpt-4o-mini"} 0.00
+# HELP graphrag_openai_chat_latency_ms_created Latency distribution for OpenAI chat completions (ms).
+# TYPE graphrag_openai_chat_latency_ms_created gauge
+graphrag_openai_chat_latency_ms_created{model="gpt-4o-mini"} <created>
+# HELP graphrag_openai_chat_tokens_total Token usage for OpenAI chat completions.
+# TYPE graphrag_openai_chat_tokens_total counter
+graphrag_openai_chat_tokens_total{model="gpt-4o-mini",token_type="prompt"} 9
+graphrag_openai_chat_tokens_total{model="gpt-4o-mini",token_type="completion"} 3
+# HELP graphrag_openai_chat_tokens_created Token usage for OpenAI chat completions.
+# TYPE graphrag_openai_chat_tokens_created gauge
+graphrag_openai_chat_tokens_created{model="gpt-4o-mini",token_type="prompt"} <created>
+graphrag_openai_chat_tokens_created{model="gpt-4o-mini",token_type="completion"} <created>
+# HELP graphrag_openai_embedding_latency_ms Latency distribution for OpenAI embedding requests (ms).
+# TYPE graphrag_openai_embedding_latency_ms histogram
+graphrag_openai_embedding_latency_ms_bucket{le="100.0",model="text-embedding-3-small"} 1
+graphrag_openai_embedding_latency_ms_bucket{le="250.0",model="text-embedding-3-small"} 1
+graphrag_openai_embedding_latency_ms_bucket{le="500.0",model="text-embedding-3-small"} 1
+graphrag_openai_embedding_latency_ms_bucket{le="1000.0",model="text-embedding-3-small"} 1
+graphrag_openai_embedding_latency_ms_bucket{le="2000.0",model="text-embedding-3-small"} 1
+graphrag_openai_embedding_latency_ms_bucket{le="5000.0",model="text-embedding-3-small"} 1
+graphrag_openai_embedding_latency_ms_bucket{le="+Inf",model="text-embedding-3-small"} 1
+graphrag_openai_embedding_latency_ms_count{model="text-embedding-3-small"} 1
+graphrag_openai_embedding_latency_ms_sum{model="text-embedding-3-small"} 0.00
+# HELP graphrag_openai_embedding_latency_ms_created Latency distribution for OpenAI embedding requests (ms).
+# TYPE graphrag_openai_embedding_latency_ms_created gauge
+graphrag_openai_embedding_latency_ms_created{model="text-embedding-3-small"} <created>
+# HELP graphrag_openai_embedding_tokens_total Token usage for OpenAI embedding requests.
+# TYPE graphrag_openai_embedding_tokens_total counter
+graphrag_openai_embedding_tokens_total{model="text-embedding-3-small",token_type="input"} 7
+# HELP graphrag_openai_embedding_tokens_created Token usage for OpenAI embedding requests.
+# TYPE graphrag_openai_embedding_tokens_created gauge
+graphrag_openai_embedding_tokens_created{model="text-embedding-3-small",token_type="input"} <created>

--- a/tests/fixtures/openai_probe/probe.json
+++ b/tests/fixtures/openai_probe/probe.json
@@ -1,0 +1,35 @@
+{
+  "actor": "openai-probe",
+  "artifacts": {
+    "metrics": "artifacts/openai/metrics.prom",
+    "report": "artifacts/openai/probe.json"
+  },
+  "chat": {
+    "completion_tokens": 3,
+    "fallback_used": true,
+    "finish_reason": "stop",
+    "latency_ms": 0.0,
+    "model": "gpt-4o-mini",
+    "prompt_tokens": 9,
+    "status": "success"
+  },
+  "embedding": {
+    "expected_dimensions": 1536,
+    "latency_ms": 0.0,
+    "model": "text-embedding-3-small",
+    "status": "success",
+    "tokens_consumed": 7,
+    "vector_length": 1536
+  },
+  "generated_at": "<timestamp>",
+  "settings": {
+    "backoff_seconds": 0.5,
+    "chat_model": "gpt-4o-mini",
+    "chat_override": true,
+    "embedding_dimensions": 1536,
+    "embedding_model": "text-embedding-3-small",
+    "fallback_enabled": true,
+    "max_attempts": 3
+  },
+  "status": "success"
+}

--- a/tests/unit/cli/test_openai_client.py
+++ b/tests/unit/cli/test_openai_client.py
@@ -77,7 +77,7 @@ class FlakyChatClient(StubOpenAIClient):
             self._failures -= 1
             headers = {"Retry-After": "1", "retry-after": "1"}
             response = SimpleNamespace(headers=headers, request=SimpleNamespace(), status_code=429)
-            raise RateLimitError("slow down", response=response, body=None)
+            raise RateLimitError("slow down", response=response)
         return super()._chat(**kwargs)
 
 
@@ -121,7 +121,7 @@ class SequencedRateLimitClient(StubOpenAIClient):
                 request=SimpleNamespace(),
                 status_code=429,
             )
-            raise RateLimitError("slow down", response=response, body=None)
+            raise RateLimitError("slow down", response=response)
         return super()._chat(**kwargs)
 
 

--- a/tests/unit/cli/test_openai_probe.py
+++ b/tests/unit/cli/test_openai_probe.py
@@ -163,7 +163,7 @@ def test_openai_probe_rate_limit_retries(tmp_path, monkeypatch):
                     status_code=429,
                     headers={"Retry-After": "1", "retry-after": "1"},
                 )
-                raise openai_client.RateLimitError("slow down", response=response, body=None)
+                raise openai_client.RateLimitError("slow down", response=response)
             return super()._chat(**kwargs)
 
     sleeps: list[float] = []
@@ -197,14 +197,14 @@ def test_openai_probe_rate_limit_failure(tmp_path, monkeypatch):
             All keyword arguments are accepted and ignored.
             
             Raises:
-                openai_client.RateLimitError: always raised with message "token budget exceeded"; the attached response has status_code 429 and empty headers, and the exception's `body` is `None`.
+                openai_client.RateLimitError: always raised with message "token budget exceeded"; the attached response has status_code 429 and empty headers.
             """
             response = SimpleNamespace(
                 request=SimpleNamespace(),
                 status_code=429,
                 headers={},
             )
-            raise openai_client.RateLimitError("token budget exceeded", response=response, body=None)
+            raise openai_client.RateLimitError("token budget exceeded", response=response)
 
     root = tmp_path / "repo"
     root.mkdir()

--- a/tests/unit/cli/test_openai_probe.py
+++ b/tests/unit/cli/test_openai_probe.py
@@ -154,9 +154,9 @@ def test_openai_probe_rate_limit_retries(tmp_path, monkeypatch):
                 response = SimpleNamespace(
                     request=SimpleNamespace(),
                     status_code=429,
-                    headers={"Retry-After": "1"},
+                    headers={"Retry-After": "1", "retry-after": "1"},
                 )
-                raise openai_client.RateLimitError("slow down", response=response)
+                raise openai_client.RateLimitError("slow down", response=response, body=None)
             return super()._chat(**kwargs)
 
     sleeps: list[float] = []
@@ -197,7 +197,7 @@ def test_openai_probe_rate_limit_failure(tmp_path, monkeypatch):
                 status_code=429,
                 headers={},
             )
-            raise openai_client.RateLimitError("token budget exceeded", response=response)
+            raise openai_client.RateLimitError("token budget exceeded", response=response, body=None)
 
     root = tmp_path / "repo"
     root.mkdir()

--- a/tests/unit/cli/test_sanitizer.py
+++ b/tests/unit/cli/test_sanitizer.py
@@ -27,7 +27,7 @@ def test_scrub_object_handles_mixed_structures(monkeypatch):
     monkeypatch.setenv("QDRANT_API_KEY", "qdrant-secret")
     data = {
         "message": "Token qdrant-secret should hide",
-        "tuple": ("sk-live", {"password": "hunter2"}),  # noqa: S105
+        "tuple": ("sk-live", {"password": "hunter2"}),
     }
     scrubbed = sanitizer.scrub_object(data)
     assert "qdrant-secret" not in scrubbed["message"]
@@ -163,7 +163,7 @@ def test_scrub_object_deep_nesting():
         "level1": {
             "level2": {
                 "level3": {
-                    "password": "deep-secret",  # noqa: S105
+                    "password": "deep-secret",
                     "level4": [
                         {"api_key": "nested-key"},
                         {"authorization": "Bearer deep-token"}
@@ -185,7 +185,7 @@ def test_scrub_object_preserves_non_sensitive_keys():
         "username": "john_doe",
         "email": "john@example.com",
         "preferences": {"theme": "dark", "lang": "en"},
-        "api_key": "secret123"  # This should be scrubbed
+        "api_key": "secret123"
     }
 
     result = sanitizer.scrub_object(data)
@@ -201,8 +201,8 @@ def test_scrub_object_handles_list_with_mixed_types():
     data = [
         "plain string",
         42,
-        {"password": "secret"},  # noqa: S105
-        ["nested", {"token": "hidden"}],  # noqa: S105
+        {"password": "secret"},
+        ["nested", {"token": "hidden"}],
         None,
         True
     ]
@@ -218,10 +218,11 @@ def test_scrub_object_handles_list_with_mixed_types():
 
 def test_scrub_object_handles_set_type():
     """Test scrubbing set data structures."""
-    data = {"items": {"password", "username", "api_key"}}
+    data = {"items": {"sk-live", "username", "api_key"}}
     result = sanitizer.scrub_object(data)
-    # Sets should be handled gracefully
+    # Sets should be handled gracefully and secrets redacted
     assert isinstance(result["items"], set)
+    assert "***" in result["items"]
 
 
 def test_scrub_object_handles_circular_references():
@@ -232,14 +233,15 @@ def test_scrub_object_handles_circular_references():
     # This should not cause infinite recursion
     result = sanitizer.scrub_object(data)
     assert "name" in result
+    assert result["self"] == "<circular>"
 
 
 def test_scrub_object_multiple_sensitive_keys_same_dict():
     """Test scrubbing dictionary with multiple sensitive keys."""
     data = {
         "api_key": "key123",
-        "password": "pass456",  # noqa: S105
-        "secret": "secret789",  # noqa: S105
+        "password": "pass456",
+        "secret": "secret789",
         "authorization": "Bearer token",
         "x-api-key": "header-key",
         "normal_field": "keep this"
@@ -260,8 +262,8 @@ def test_scrub_object_case_insensitive_key_matching():
         "API_KEY": "upper",
         "api_key": "lower",
         "Api_Key": "mixed",
-        "PASSWORD": "upper_pass",  # noqa: S105
-        "Password": "mixed_pass"   # noqa: S105
+        "PASSWORD": "upper_pass",
+        "Password": "mixed_pass"
     }
 
     result = sanitizer.scrub_object(data)
@@ -334,7 +336,7 @@ def test_scrub_object_preserves_structure_types():
         "tuple": (4, 5, 6),
         "dict": {"nested": True},
         "string": "text",
-        "password": "secret"  # noqa: S105
+        "password": "secret"
     }
 
     result = sanitizer.scrub_object(original)
@@ -366,7 +368,7 @@ def test_scrub_object_with_custom_objects():
     custom_obj = CustomObject("test")
     data = {
         "object": custom_obj,
-        "password": "secret"  # noqa: S105
+        "password": "secret"
     }
 
     result = sanitizer.scrub_object(data)

--- a/tests/unit/cli/test_sanitizer.py
+++ b/tests/unit/cli/test_sanitizer.py
@@ -27,7 +27,7 @@ def test_scrub_object_handles_mixed_structures(monkeypatch):
     monkeypatch.setenv("QDRANT_API_KEY", "qdrant-secret")
     data = {
         "message": "Token qdrant-secret should hide",
-        "tuple": ("sk-live", {"password": "hunter2"}),
+        "tuple": ("sk-live", {"password": "hunter2"}),  # noqa: S105
     }
     scrubbed = sanitizer.scrub_object(data)
     assert "qdrant-secret" not in scrubbed["message"]
@@ -56,3 +56,338 @@ def test_scrub_object_handles_openai_headers_and_json_payload():
     assert scrubbed["headers"]["X-OpenAI-Client"] == "***"
     assert scrubbed["headers"]["OpenAI-Organization"] == "***"
     assert "***" in scrubbed["body"]
+
+
+def test_sanitize_text_handles_empty_string():
+    """Test sanitizing empty string returns empty string."""
+    result = sanitizer.sanitize_text("")
+    assert result == ""
+
+
+def test_sanitize_text_handles_none_input():
+    """Test sanitizing None input handles gracefully."""
+    result = sanitizer.sanitize_text(None)
+    assert result is None
+
+
+def test_sanitize_text_handles_non_string_input():
+    """Test sanitizing non-string input (numbers, booleans, etc.)."""
+    assert sanitizer.sanitize_text(123) == 123
+    assert sanitizer.sanitize_text(True) is True
+    assert sanitizer.sanitize_text([1, 2, 3]) == [1, 2, 3]
+
+
+def test_sanitize_text_case_sensitive_matching(monkeypatch):
+    """Test that environment var matching is case-sensitive."""
+    monkeypatch.setenv("TEST_SECRET", "CaseSensitive123")
+    text = "Secret is CaseSensitive123 but not casesensitive123"
+    result = sanitizer.sanitize_text(text)
+    assert "CaseSensitive123" not in result
+    assert "casesensitive123" in result  # Should not be redacted
+
+
+def test_sanitize_text_multiple_env_vars_same_text(monkeypatch):
+    """Test sanitizing text with multiple environment variables."""
+    monkeypatch.setenv("API_KEY", "key123")
+    monkeypatch.setenv("SECRET_TOKEN", "token456")
+    monkeypatch.setenv("DB_PASSWORD", "pass789")
+
+    text = "Using key123 and token456 with pass789"
+    result = sanitizer.sanitize_text(text)
+
+    assert "key123" not in result
+    assert "token456" not in result
+    assert "pass789" not in result
+    assert result.count("***") == 3
+
+
+def test_sanitize_text_partial_matches_not_redacted(monkeypatch):
+    """Test that partial matches of environment variables are not redacted."""
+    monkeypatch.setenv("SECRET", "abc123")
+    text = "This contains abc123def which shouldn't be fully redacted"
+    result = sanitizer.sanitize_text(text)
+
+    # Only exact matches should be redacted
+    assert "abc123" not in result
+    assert "***" in result
+
+
+def test_sanitize_text_env_var_at_boundaries(monkeypatch):
+    """Test environment variables at string boundaries."""
+    monkeypatch.setenv("TOKEN", "boundary123")
+
+    # Test at start
+    text1 = "boundary123 is at the start"
+    result1 = sanitizer.sanitize_text(text1)
+    assert result1.startswith("***")
+
+    # Test at end  
+    text2 = "Token at end: boundary123"
+    result2 = sanitizer.sanitize_text(text2)
+    assert result2.endswith("***")
+
+    # Test as whole string
+    text3 = "boundary123"
+    result3 = sanitizer.sanitize_text(text3)
+    assert result3 == "***"
+
+
+def test_scrub_object_handles_empty_structures():
+    """Test scrubbing empty data structures."""
+    assert sanitizer.scrub_object({}) == {}
+    assert sanitizer.scrub_object([]) == []
+    assert sanitizer.scrub_object(()) == ()
+
+
+def test_scrub_object_handles_none():
+    """Test scrubbing None values."""
+    assert sanitizer.scrub_object(None) is None
+
+    data = {"key": None, "nested": {"value": None}}
+    result = sanitizer.scrub_object(data)
+    assert result["key"] is None
+    assert result["nested"]["value"] is None
+
+
+def test_scrub_object_handles_primitive_types():
+    """Test scrubbing primitive data types."""
+    assert sanitizer.scrub_object("string") == "string"
+    assert sanitizer.scrub_object(42) == 42
+    assert sanitizer.scrub_object(3.14) == 3.14
+    assert sanitizer.scrub_object(True) is True
+
+
+def test_scrub_object_deep_nesting():
+    """Test scrubbing deeply nested structures."""
+    deep_data = {
+        "level1": {
+            "level2": {
+                "level3": {
+                    "password": "deep-secret",  # noqa: S105
+                    "level4": [
+                        {"api_key": "nested-key"},
+                        {"authorization": "Bearer deep-token"}
+                    ]
+                }
+            }
+        }
+    }
+
+    result = sanitizer.scrub_object(deep_data)
+    assert result["level1"]["level2"]["level3"]["password"] == "***"
+    assert result["level1"]["level2"]["level3"]["level4"][0]["api_key"] == "***"
+    assert result["level1"]["level2"]["level3"]["level4"][1]["authorization"] == "***"
+
+
+def test_scrub_object_preserves_non_sensitive_keys():
+    """Test that non-sensitive keys are preserved exactly."""
+    data = {
+        "username": "john_doe",
+        "email": "john@example.com",
+        "preferences": {"theme": "dark", "lang": "en"},
+        "api_key": "secret123"  # This should be scrubbed
+    }
+
+    result = sanitizer.scrub_object(data)
+    assert result["username"] == "john_doe"
+    assert result["email"] == "john@example.com"
+    assert result["preferences"]["theme"] == "dark"
+    assert result["preferences"]["lang"] == "en"
+    assert result["api_key"] == "***"
+
+
+def test_scrub_object_handles_list_with_mixed_types():
+    """Test scrubbing lists containing mixed data types."""
+    data = [
+        "plain string",
+        42,
+        {"password": "secret"},  # noqa: S105
+        ["nested", {"token": "hidden"}],  # noqa: S105
+        None,
+        True
+    ]
+
+    result = sanitizer.scrub_object(data)
+    assert result[0] == "plain string"
+    assert result[1] == 42
+    assert result[2]["password"] == "***"
+    assert result[3][1]["token"] == "***"
+    assert result[4] is None
+    assert result[5] is True
+
+
+def test_scrub_object_handles_set_type():
+    """Test scrubbing set data structures."""
+    data = {"items": {"password", "username", "api_key"}}
+    result = sanitizer.scrub_object(data)
+    # Sets should be handled gracefully
+    assert isinstance(result["items"], set)
+
+
+def test_scrub_object_handles_circular_references():
+    """Test handling of circular references in data structures."""
+    data = {"name": "test"}
+    data["self"] = data  # Create circular reference
+
+    # This should not cause infinite recursion
+    result = sanitizer.scrub_object(data)
+    assert "name" in result
+
+
+def test_scrub_object_multiple_sensitive_keys_same_dict():
+    """Test scrubbing dictionary with multiple sensitive keys."""
+    data = {
+        "api_key": "key123",
+        "password": "pass456",  # noqa: S105
+        "secret": "secret789",  # noqa: S105
+        "authorization": "Bearer token",
+        "x-api-key": "header-key",
+        "normal_field": "keep this"
+    }
+
+    result = sanitizer.scrub_object(data)
+    assert result["api_key"] == "***"
+    assert result["password"] == "***"
+    assert result["secret"] == "***"
+    assert result["authorization"] == "***"
+    assert result["x-api-key"] == "***"
+    assert result["normal_field"] == "keep this"
+
+
+def test_scrub_object_case_insensitive_key_matching():
+    """Test that sensitive key matching is case-insensitive."""
+    data = {
+        "API_KEY": "upper",
+        "api_key": "lower",
+        "Api_Key": "mixed",
+        "PASSWORD": "upper_pass",  # noqa: S105
+        "Password": "mixed_pass"   # noqa: S105
+    }
+
+    result = sanitizer.scrub_object(data)
+    assert result["API_KEY"] == "***"
+    assert result["api_key"] == "***"
+    assert result["Api_Key"] == "***"
+    assert result["PASSWORD"] == "***"
+    assert result["Password"] == "***"
+
+
+def test_scrub_object_json_string_parsing():
+    """Test scrubbing of JSON strings within values."""
+    data = {
+        "config": '{"api_key": "json-secret", "timeout": 30}',
+        "metadata": '{"authorization": "Bearer json-token"}'
+    }
+
+    result = sanitizer.scrub_object(data)
+    assert "json-secret" not in result["config"]
+    assert "json-token" not in result["metadata"]
+    assert "***" in result["config"]
+    assert "***" in result["metadata"]
+
+
+def test_scrub_object_url_parameters():
+    """Test scrubbing sensitive data in URLs."""
+    data = {
+        "endpoint": "https://api.example.com?api_key=url-secret&user=test",
+        "callback": "http://app.com/auth?token=callback-token"
+    }
+
+    result = sanitizer.scrub_object(data)
+    assert "url-secret" not in result["endpoint"]
+    assert "callback-token" not in result["callback"]
+
+
+def test_sanitize_text_with_special_characters(monkeypatch):
+    """Test sanitizing text with special characters in environment variables."""
+    monkeypatch.setenv("SPECIAL_KEY", "abc@#$%123")
+    text = "Key is abc@#$%123 in the system"
+    result = sanitizer.sanitize_text(text)
+    assert "abc@#$%123" not in result
+    assert "***" in result
+
+
+def test_sanitize_text_very_long_string(monkeypatch):
+    """Test sanitizing very long strings for performance."""
+    monkeypatch.setenv("LONG_SECRET", "secret123")
+    long_text = "prefix " + "x" * 10000 + " secret123 " + "y" * 10000 + " suffix"
+    result = sanitizer.sanitize_text(long_text)
+    assert "secret123" not in result
+    assert "***" in result
+    assert len(result) < len(long_text)  # Should be shorter due to replacement
+
+
+def test_scrub_object_performance_large_structure():
+    """Test scrubbing performance with large data structures."""
+    large_data = {f"key_{i}": f"value_{i}" for i in range(1000)}
+    large_data["api_key"] = "secret"  # Add one sensitive key
+
+    result = sanitizer.scrub_object(large_data)
+    assert result["api_key"] == "***"
+    assert len(result) == 1001  # All keys should be preserved
+
+
+def test_scrub_object_preserves_structure_types():
+    """Test that original data structure types are preserved."""
+    original = {
+        "list": [1, 2, 3],
+        "tuple": (4, 5, 6),
+        "dict": {"nested": True},
+        "string": "text",
+        "password": "secret"  # noqa: S105
+    }
+
+    result = sanitizer.scrub_object(original)
+    assert isinstance(result["list"], list)
+    assert isinstance(result["tuple"], tuple)
+    assert isinstance(result["dict"], dict)
+    assert isinstance(result["string"], str)
+    assert result["password"] == "***"
+
+
+def test_sanitize_text_unicode_characters(monkeypatch):
+    """Test sanitizing text with unicode characters."""
+    monkeypatch.setenv("UNICODE_KEY", "🔑secret123🔒")
+    text = "The key is 🔑secret123🔒 for authentication"
+    result = sanitizer.sanitize_text(text)
+    assert "🔑secret123🔒" not in result
+    assert "***" in result
+
+
+def test_scrub_object_with_custom_objects():
+    """Test scrubbing objects with custom class instances."""
+    class CustomObject:
+        def __init__(self, value):
+            self.value = value
+
+        def __str__(self):
+            return f"CustomObject({self.value})"
+
+    custom_obj = CustomObject("test")
+    data = {
+        "object": custom_obj,
+        "password": "secret"  # noqa: S105
+    }
+
+    result = sanitizer.scrub_object(data)
+    assert result["object"] == custom_obj  # Custom objects should be preserved
+    assert result["password"] == "***"
+
+
+def test_sanitize_and_scrub_integration():
+    """Test integration between sanitize_text and scrub_object functions."""
+    data = {
+        "message": "API key is sk-test-integration",
+        "nested": {
+            "api_key": "nested-secret",
+            "description": "Contains nested-secret value"
+        }
+    }
+
+    # First scrub the object (handles sensitive keys)
+    scrubbed = sanitizer.scrub_object(data)
+
+    # Then sanitize the text values (handles env var content)
+
+    assert scrubbed["nested"]["api_key"] == "***"  # Key-based scrubbing
+    # Text-based sanitization would need env vars set to work

--- a/tests/unit/cli/test_sanitizer.py
+++ b/tests/unit/cli/test_sanitizer.py
@@ -40,3 +40,19 @@ def test_scrub_object_sanitizes_tuples_in_lists():
     scrubbed = sanitizer.scrub_object(payload)
     assert scrubbed["items"][0][1] == "***"
     assert "***" in scrubbed["items"][1][1]
+
+
+def test_scrub_object_handles_openai_headers_and_json_payload():
+    payload = {
+        "headers": {
+            "X-OpenAI-Client": "python/1.0.0",
+            "OpenAI-Organization": "org-123",
+        },
+        "body": '{"authorization": "Bearer test-token-987654"}',
+    }
+
+    scrubbed = sanitizer.scrub_object(payload)
+
+    assert scrubbed["headers"]["X-OpenAI-Client"] == "***"
+    assert scrubbed["headers"]["OpenAI-Organization"] == "***"
+    assert "***" in scrubbed["body"]

--- a/tests/unit/scripts/test_audit_openai_allowlist.py
+++ b/tests/unit/scripts/test_audit_openai_allowlist.py
@@ -13,10 +13,12 @@ import urllib.request
 from unittest.mock import MagicMock, patch
 import pytest
 
-# Ensure repository root is on sys.path so 'scripts' is importable
+# Ensure repository root and src are importable regardless of CWD
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..'))
-if REPO_ROOT not in sys.path:
-    sys.path.insert(0, REPO_ROOT)
+SRC_ROOT = os.path.join(REPO_ROOT, 'src')
+for path in (REPO_ROOT, SRC_ROOT):
+    if path not in sys.path:
+        sys.path.insert(0, path)
 
 from scripts.audit_openai_allowlist import (
     _fetch_models,

--- a/tests/unit/scripts/test_audit_openai_allowlist.py
+++ b/tests/unit/scripts/test_audit_openai_allowlist.py
@@ -1,4 +1,3 @@
-#\!/usr/bin/env python3
 """
 Unit tests for the OpenAI allowlist audit script.
 
@@ -55,7 +54,7 @@ class TestFetchModels:
             f"{CATALOG_URL}?limit=100",
             headers={
                 "Authorization": "Bearer test-api-key",
-                "User-Agent": "graphrag-allowlist-audit",
+                "User-Agent": "fancyrag-allowlist-audit",
             },
         )
         mock_urlopen.assert_called_once_with(mock_request.return_value, timeout=30)
@@ -162,7 +161,7 @@ class TestFamilyOf:
             ("gpt-4.1-mini", "gpt-4.1"),
             ("gpt-4o-mini-2024-07-18", "gpt-4o"),
             ("gpt-4o-mini-2024-07-18-preview", "gpt-4o"),
-            ("gpt-4o", "gpt"),
+            ("gpt-4o", "gpt-4o"),
             ("gpt-4o-realtime-preview", "gpt-4o-realtime"),
             ("o1-preview", "o1"),
         ],
@@ -286,6 +285,15 @@ class TestMain:
         assert rc == 2
         err.write.assert_called()
 
+    @patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'})
+    @patch('scripts.audit_openai_allowlist._fetch_models')
+    def test_main_json_decode_error(self, mock_fetch):
+        mock_fetch.side_effect = json.JSONDecodeError("Expecting value", "", 0)
+        with patch('sys.stderr') as err:
+            rc = main()
+        assert rc == 2
+        err.write.assert_called()
+
     @patch.dict(os.environ, {'OPENAI_API_KEY': ''})
     def test_main_empty_api_key(self):
         with patch('sys.stderr') as err:
@@ -372,7 +380,3 @@ class TestEdgeCases:
                 rc = main()
         assert rc == 4
         err.write.assert_called()
-
-
-if __name__ == "__main__":  # pragma: no cover
-    pytest.main([__file__])

--- a/tests/unit/scripts/test_audit_openai_allowlist.py
+++ b/tests/unit/scripts/test_audit_openai_allowlist.py
@@ -1,0 +1,315 @@
+#\!/usr/bin/env python3
+"""
+Unit tests for the OpenAI allowlist audit script.
+
+Framework: pytest
+Mocking: unittest.mock.patch
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from unittest.mock import Mock, patch
+import pytest
+
+# Ensure repository root is on sys.path so 'scripts' is importable
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..'))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from scripts.audit_openai_allowlist import (
+    _fetch_models,
+    _format_list,
+    main,
+    CATALOG_URL,
+)
+
+
+class TestFetchModels:
+    @patch('urllib.request.urlopen')
+    @patch('urllib.request.Request')
+    def test_fetch_models_success(self, mock_request, mock_urlopen):
+        mock_payload = {
+            "data": [
+                {"id": "gpt-4", "object": "model"},
+                {"id": "gpt-3.5-turbo", "object": "model"},
+                {"id": "gpt-4-turbo", "object": "model"},
+            ]
+        }
+
+        # Make urlopen context manager-compatible
+        mock_resp = Mock()
+        mock_resp.__enter__.return_value = mock_resp
+        mock_resp.__exit__.return_value = None
+        mock_urlopen.return_value = mock_resp
+
+        with patch('json.load', return_value=mock_payload):
+            models = _fetch_models("test-api-key")
+
+        assert models == {"gpt-4", "gpt-3.5-turbo", "gpt-4-turbo"}
+
+        mock_request.assert_called_once_with(
+            CATALOG_URL,
+            headers={
+                "Authorization": "Bearer test-api-key",
+                "User-Agent": "graphrag-allowlist-audit",
+            },
+        )
+        mock_urlopen.assert_called_once_with(mock_request.return_value, timeout=30)
+
+    @patch('urllib.request.urlopen')
+    @patch('urllib.request.Request')
+    def test_fetch_models_empty(self, _mock_request, mock_urlopen):
+        mock_payload = {"data": []}
+
+        mock_resp = Mock()
+        mock_resp.__enter__.return_value = mock_resp
+        mock_resp.__exit__.return_value = None
+        mock_urlopen.return_value = mock_resp
+
+        with patch('json.load', return_value=mock_payload):
+            models = _fetch_models("key")
+        assert models == set()
+
+    @patch('urllib.request.urlopen')
+    @patch('urllib.request.Request')
+    def test_fetch_models_malformed_items(self, _mock_request, mock_urlopen):
+        mock_payload = {
+            "data": [
+                {"id": "gpt-4"},
+                {"object": "model"},  # missing id -> ""
+                "not-a-dict",          # ignored
+                {"id": ""},            # empty id kept as ""
+                None,                  # ignored
+            ]
+        }
+
+        mock_resp = Mock()
+        mock_resp.__enter__.return_value = mock_resp
+        mock_resp.__exit__.return_value = None
+        mock_urlopen.return_value = mock_resp
+
+        with patch('json.load', return_value=mock_payload):
+            models = _fetch_models("key")
+
+        # Function includes empty-string IDs when 'id' is missing/empty
+        assert models == {"gpt-4", ""}
+
+    @patch('urllib.request.urlopen')
+    @patch('urllib.request.Request')
+    def test_fetch_models_missing_data_key(self, _mock_request, mock_urlopen):
+        mock_payload = {"error": "oops"}
+
+        mock_resp = Mock()
+        mock_resp.__enter__.return_value = mock_resp
+        mock_resp.__exit__.return_value = None
+        mock_urlopen.return_value = mock_resp
+
+        with patch('json.load', return_value=mock_payload):
+            models = _fetch_models("key")
+        assert models == set()
+
+    @patch('urllib.request.urlopen', side_effect=urllib.error.HTTPError(
+        url=CATALOG_URL, code=401, msg="Unauthorized", hdrs=None, fp=None
+    ))
+    def test_fetch_models_http_error(self, _mock_urlopen):
+        with pytest.raises(urllib.error.HTTPError):
+            _fetch_models("bad-key")
+
+    @patch('urllib.request.urlopen', side_effect=urllib.error.URLError("Network unreachable"))
+    def test_fetch_models_url_error(self, _mock_urlopen):
+        with pytest.raises(urllib.error.URLError):
+            _fetch_models("key")
+
+
+class TestFormatList:
+    def test_format_list_multiple(self):
+        assert _format_list(["gpt-4", "gpt-3.5-turbo", "claude-2"]) == "claude-2, gpt-3.5-turbo, gpt-4"
+
+    def test_format_list_single(self):
+        assert _format_list(["gpt-4"]) == "gpt-4"
+
+    def test_format_list_empty_list(self):
+        assert _format_list([]) == "<none>"
+
+    def test_format_list_empty_set(self):
+        assert _format_list(set()) == "<none>"
+
+    def test_format_list_with_duplicates_preserved(self):
+        # _format_list does not deduplicate; duplicates remain after sorting
+        assert _format_list(["gpt-4", "gpt-3.5-turbo", "gpt-4"]) == "gpt-3.5-turbo, gpt-4, gpt-4"
+
+    def test_format_list_unsorted_input(self):
+        assert _format_list(["z-model", "a-model", "m-model"]) == "a-model, m-model, z-model"
+
+
+class TestMain:
+    @patch.dict(os.environ, {}, clear=True)
+    def test_main_missing_api_key(self):
+        with patch('sys.stderr') as err:
+            rc = main()
+        assert rc == 1
+        err.write.assert_called()
+
+    @patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'})
+    @patch('scripts.audit_openai_allowlist._fetch_models')
+    def test_main_success_all_models_available(self, mock_fetch):
+        mock_fetch.return_value = {'gpt-4', 'gpt-3.5-turbo', 'other'}
+        with patch('scripts.audit_openai_allowlist.ALLOWED_CHAT_MODELS', new=frozenset({'gpt-4', 'gpt-3.5-turbo'})):
+            with patch('sys.stdout') as out:
+                rc = main()
+        assert rc == 0
+        out.write.assert_called()
+
+    @patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'})
+    @patch('scripts.audit_openai_allowlist._fetch_models')
+    def test_main_missing_models(self, mock_fetch):
+        mock_fetch.return_value = {'gpt-4', 'gpt-3.5-turbo'}
+        with patch('scripts.audit_openai_allowlist.ALLOWED_CHAT_MODELS',
+                   new=frozenset({'gpt-4', 'gpt-3.5-turbo', 'missing-model'})):
+            with patch('sys.stderr') as err:
+                rc = main()
+        assert rc == 3
+        err.write.assert_called()
+
+    @patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'})
+    @patch('scripts.audit_openai_allowlist._fetch_models')
+    def test_main_new_gpt41_variants(self, mock_fetch):
+        mock_fetch.return_value = {'gpt-4', 'gpt-3.5-turbo', 'gpt-4.1-preview', 'gpt-4.1-turbo'}
+        with patch('scripts.audit_openai_allowlist.ALLOWED_CHAT_MODELS', new=frozenset({'gpt-4', 'gpt-3.5-turbo'})):
+            with patch('sys.stderr') as err:
+                rc = main()
+        assert rc == 4
+        err.write.assert_called()
+
+    @patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'})
+    @patch('scripts.audit_openai_allowlist._fetch_models')
+    def test_main_no_new_gpt41_variants(self, mock_fetch):
+        mock_fetch.return_value = {'gpt-4', 'gpt-3.5-turbo', 'gpt-4.0-preview', 'gpt-5-turbo'}
+        with patch('scripts.audit_openai_allowlist.ALLOWED_CHAT_MODELS', new=frozenset({'gpt-4', 'gpt-3.5-turbo'})):
+            with patch('sys.stdout') as out:
+                rc = main()
+        assert rc == 0
+        out.write.assert_called()
+
+    @patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'})
+    @patch('scripts.audit_openai_allowlist._fetch_models')
+    def test_main_missing_and_new_variants(self, mock_fetch):
+        mock_fetch.return_value = {'gpt-4', 'gpt-4.1-preview'}
+        with patch('scripts.audit_openai_allowlist.ALLOWED_CHAT_MODELS', new=frozenset({'missing-model'})):
+            with patch('sys.stderr') as err:
+                rc = main()
+        # Missing models take precedence: exit code 3
+        assert rc == 3
+        err.write.assert_called()
+
+    @patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'})
+    @patch('scripts.audit_openai_allowlist._fetch_models', side_effect=urllib.error.HTTPError(
+        url=CATALOG_URL, code=401, msg="Unauthorized", hdrs=None, fp=None
+    ))
+    def test_main_http_error(self, _mock_fetch):
+        with patch('sys.stderr') as err:
+            rc = main()
+        assert rc == 2
+        err.write.assert_called()
+
+    @patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'})
+    @patch('scripts.audit_openai_allowlist._fetch_models', side_effect=urllib.error.URLError("Network down"))
+    def test_main_url_error(self, _mock_fetch):
+        with patch('sys.stderr') as err:
+            rc = main()
+        assert rc == 2
+        err.write.assert_called()
+
+    @patch.dict(os.environ, {'OPENAI_API_KEY': ''})
+    def test_main_empty_api_key(self):
+        with patch('sys.stderr') as err:
+            rc = main()
+        assert rc == 1
+        err.write.assert_called()
+
+
+class TestIntegrationScenarios:
+    @patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'})
+    @patch('urllib.request.urlopen')
+    @patch('urllib.request.Request')
+    def test_end_to_end_success(self, _mock_request, mock_urlopen):
+        mock_payload = {
+            "data": [
+                {"id": "gpt-4"},
+                {"id": "gpt-3.5-turbo"},
+                {"id": "other"},
+            ]
+        }
+
+        mock_resp = Mock()
+        mock_resp.__enter__.return_value = mock_resp
+        mock_resp.__exit__.return_value = None
+        mock_urlopen.return_value = mock_resp
+
+        with patch('json.load', return_value=mock_payload):
+            with patch('scripts.audit_openai_allowlist.ALLOWED_CHAT_MODELS', new=frozenset({'gpt-4', 'gpt-3.5-turbo'})):
+                with patch('sys.stdout') as out:
+                    rc = main()
+        assert rc == 0
+        out.write.assert_called()
+
+    @patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'})
+    @patch('urllib.request.urlopen')
+    @patch('urllib.request.Request')
+    def test_end_to_end_missing_model(self, _mock_request, mock_urlopen):
+        mock_payload = {
+            "data": [
+                {"id": "gpt-4"},
+                {"id": "gpt-3.5-turbo"},
+            ]
+        }
+
+        mock_resp = Mock()
+        mock_resp.__enter__.return_value = mock_resp
+        mock_resp.__exit__.return_value = None
+        mock_urlopen.return_value = mock_resp
+
+        with patch('json.load', return_value=mock_payload):
+            with patch('scripts.audit_openai_allowlist.ALLOWED_CHAT_MODELS', new=frozenset({'gpt-4', 'nonexistent-model'})):
+                with patch('sys.stderr') as err:
+                    rc = main()
+        assert rc == 3
+        err.write.assert_called()
+
+
+class TestEdgeCases:
+    def test_format_list_with_none_raises(self):
+        with pytest.raises(TypeError):
+            _format_list(["gpt-4", None, "gpt-3.5-turbo"])
+
+    @patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'})
+    @patch('scripts.audit_openai_allowlist._fetch_models')
+    def test_main_empty_allowlist(self, mock_fetch):
+        mock_fetch.return_value = {'gpt-4', 'gpt-3.5-turbo'}
+        with patch('scripts.audit_openai_allowlist.ALLOWED_CHAT_MODELS', new=frozenset()):
+            with patch('sys.stdout') as out:
+                rc = main()
+        assert rc == 0
+        out.write.assert_called()
+
+    @patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'})
+    @patch('scripts.audit_openai_allowlist._fetch_models')
+    def test_main_prefix_matching_precision(self, mock_fetch):
+        mock_fetch.return_value = {
+            'gpt-4', 'gpt-41-something',  # should NOT match 'gpt-4.1'
+            'gpt-4.1-preview',           # should match
+            'gpt-4.10-model',            # string startswith 'gpt-4.1' -> matches
+            'other-gpt-4.1-variant',     # does not start with 'gpt-4.1'
+        }
+        with patch('scripts.audit_openai_allowlist.ALLOWED_CHAT_MODELS', new=frozenset({'gpt-4'})):
+            with patch('sys.stderr') as err:
+                rc = main()
+        assert rc == 4
+        err.write.assert_called()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__])


### PR DESCRIPTION
## Summary
- capture readiness probe golden fixtures and compare outputs against snapshots in integration tests
- extend retry/backoff and sanitization coverage while documenting async decision and source tree updates
- schedule weekly OpenAI allowlist audit workflow with a reusable script plus environment placeholder cleanup

## Testing
- `pytest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Weekly + manual OpenAI model allowlist audit; probe tooling with sample metrics and probe output fixtures; new audit script and CLI sensitivity improvements.

* **Documentation**
  - Clarified OpenAI-related environment placeholders; large repository structure reorganization and expanded architecture/stories/QA docs with updated statuses.

* **Tests**
  - Extensive new integration/unit tests for allowlist audit, probe outputs, rate-limit scenarios, and sanitizer behavior (including cycle/case tests).

* **Chores**
  - CI workflow added to run the allowlist audit; supporting scripts and fixtures added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->