### PR TITLE
fix: address review feedback for minimal path automation

### DIFF
--- a/docker-compose.neo4j-qdrant.yml
+++ b/docker-compose.neo4j-qdrant.yml
@@ -33,7 +33,7 @@ services:
       start_period: 40s
 
   qdrant:
-    image: qdrant/qdrant:1.9.4-debug
+    image: qdrant/qdrant:1.9.4
     container_name: qdrant-graphrag
     restart: unless-stopped
     environment:
@@ -47,12 +47,6 @@ services:
       - type: bind
         source: ./.data/qdrant/storage
         target: /qdrant/storage
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:6333/readyz"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 40s
 
 networks:
   default:

--- a/scripts/config/kg_schema.json
+++ b/scripts/config/kg_schema.json
@@ -1,0 +1,22 @@
+{
+  "node_types": [
+    {"label": "Document", "additional_properties": true},
+    {"label": "Chunk", "additional_properties": true},
+    {"label": "Company", "additional_properties": true},
+    {"label": "Product", "additional_properties": true},
+    {"label": "Operator", "additional_properties": true}
+  ],
+  "relationship_types": [
+    {"label": "HAS_CHUNK", "additional_properties": true},
+    {"label": "LAUNCHED", "additional_properties": true},
+    {"label": "INGESTED_BY", "additional_properties": true}
+  ],
+  "patterns": [
+    ["Document", "HAS_CHUNK", "Chunk"],
+    ["Company", "LAUNCHED", "Product"],
+    ["Chunk", "INGESTED_BY", "Operator"]
+  ],
+  "additional_node_types": false,
+  "additional_relationship_types": false,
+  "additional_patterns": false
+}

--- a/tests/integration/local_stack/test_minimal_path_smoke.py
+++ b/tests/integration/local_stack/test_minimal_path_smoke.py
@@ -74,7 +74,7 @@ def test_minimal_path_smoke() -> None:
     env["COMPOSE_FILE"] = str(COMPOSE_FILE)
     env["PYTHONPATH"] = "stubs:src"
     env["NEO4J_USERNAME"] = os.environ.get("NEO4J_USERNAME", "neo4j")
-    env["NEO4J_PASSWORD"] = os.environ.get("NEO4J_PASSWORD", "local-neo4j")
+    env["NEO4J_PASSWORD"] = os.environ.get("NEO4J_PASSWORD", "neo4j")
     env["NEO4J_AUTH"] = f"{env['NEO4J_USERNAME']}/{env['NEO4J_PASSWORD']}"
     env["NEO4J_URI"] = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
     env["NEO4J_BOLT_ADVERTISED_ADDRESS"] = os.environ.get("NEO4J_BOLT_ADVERTISED_ADDRESS", "localhost:7687")


### PR DESCRIPTION
## Summary
- revert the qdrant compose service to the production image and shift readiness probing into `check_local_stack.sh`
- externalize the KG schema JSON, normalise OpenAI responses with Pydantic models, and run the pipeline through the async Neo4j driver
- align the smoke-test Neo4j defaults and update KG build unit tests to cover the async driver path

## Testing
- pytest tests/unit/scripts/test_kg_build.py -q *(fails: ModuleNotFoundError: No module named 'neo4j')*
- pytest tests/unit/scripts/test_create_vector_index.py -q *(fails: ModuleNotFoundError: No module named 'neo4j')*


------
https://chatgpt.com/codex/tasks/task_e_68db74f9f59c8322af29cbb65a2cf408