### PR TITLE
fix: address review feedback for local stack hardening

### DIFF
--- a/.github/workflows/local-stack-smoke.yml
+++ b/.github/workflows/local-stack-smoke.yml
@@ -40,19 +40,19 @@ jobs:
         run: |
           cp .env.example .env
           python - <<'PY'
-import os
-from pathlib import Path
+          import os
+          from pathlib import Path
 
-env_path = Path('.env')
-lines = []
-with env_path.open() as fh:
-    for line in fh:
-        if line.startswith('OPENAI_API_KEY='):
-            lines.append(f"OPENAI_API_KEY=\"{os.environ['OPENAI_API_KEY']}\"\n")
-        else:
-            lines.append(line)
-env_path.write_text(''.join(lines))
-PY
+          env_path = Path('.env')
+          lines = []
+          with env_path.open() as fh:
+              for line in fh:
+                  if line.startswith('OPENAI_API_KEY='):
+                      lines.append(f"OPENAI_API_KEY=\"{os.environ['OPENAI_API_KEY']}\"\n")
+                  else:
+                      lines.append(line)
+          env_path.write_text(''.join(lines))
+          PY
 
       - name: Validate compose configuration
         run: scripts/check_local_stack.sh --config

--- a/scripts/kg_build.py
+++ b/scripts/kg_build.py
@@ -200,7 +200,7 @@ class SanitizingNeo4jWriter(Neo4jWriter):
     async def run(  # type: ignore[override]
         self,
         graph,
-        lexical_graph_config: LexicalGraphConfig = LexicalGraphConfig(),
+        lexical_graph_config: LexicalGraphConfig | None = None,
     ) -> KGWriterModel:
         """
         Run the writer against the provided lexical graph using the given configuration.
@@ -211,6 +211,8 @@ class SanitizingNeo4jWriter(Neo4jWriter):
         Returns:
         	KGWriterModel: Model summarizing the result of the write operation (nodes/relationships created or updated and related metadata).
         """
+        if lexical_graph_config is None:
+            lexical_graph_config = LexicalGraphConfig()
         return await super().run(graph, lexical_graph_config)
 
 


### PR DESCRIPTION
## Summary
- fix the Python heredoc indentation in the local stack smoke workflow so YAML parsers accept it
- guard the ask_qdrant CLI against OpenAI embedding failures and align environment access patterns
- validate Qdrant export embeddings per record and avoid sharing a LexicalGraphConfig default instance

## Testing
- pytest tests/unit/scripts/test_ask_qdrant.py tests/unit/scripts/test_export_to_qdrant.py tests/unit/scripts/test_kg_build.py *(fails: missing optional dependencies such as neo4j and prometheus_client)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5e3f0f2c83228699471294a49040