### PR TITLE
chore: address review feedback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,13 +19,13 @@ NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=neo4j
 NEO4J_URI="bolt://localhost:7687"  # Docker Compose defaults; override for managed instances
 # Optional advertised addresses for reverse proxies (compose sets defaults automatically)
-NEO4J_BOLT_ADVERTISED_ADDRESS="localhost:7687"
-NEO4J_HTTP_ADVERTISED_ADDRESS="localhost:7474"
+NEO4J_BOLT_ADVERTISED_ADDRESS=localhost:7687
+NEO4J_HTTP_ADVERTISED_ADDRESS=localhost:7474
 # Local compose port bindings (host ports -> container ports)
 NEO4J_HTTP_PORT=7474
 NEO4J_BOLT_PORT=7687
-QDRANT_HTTP_PORT=6333
 QDRANT_GRPC_PORT=6334
+QDRANT_HTTP_PORT=6333
 
 # Qdrant configuration
 QDRANT_URL="http://localhost:6333"

--- a/tests/unit/scripts/test_kg_build.py
+++ b/tests/unit/scripts/test_kg_build.py
@@ -1,4 +1,4 @@
-# ruff: noqa
+# ruff: noqa: E402
 
 from __future__ import annotations
 
@@ -289,8 +289,7 @@ def test_missing_file_raises(env, monkeypatch):  # noqa: ARG001 - env fixture fo
 
 # --- Additional tests for scripts/kg_build.py (pytest) ---
 
-def test_parse_args_defaults() -> None:
-    monkeypatch = pytest.MonkeyPatch()
+def test_parse_args_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("NEO4J_DATABASE", raising=False)
     args = kg._parse_args([])
     assert args.source == str(kg.DEFAULT_SOURCE)
@@ -298,7 +297,6 @@ def test_parse_args_defaults() -> None:
     assert args.chunk_overlap == kg.DEFAULT_CHUNK_OVERLAP
     assert args.database is None
     assert args.log_path == str(kg.DEFAULT_LOG_PATH)
-    monkeypatch.undo()
 
 def test_parse_args_overrides() -> None:
     args = kg._parse_args(


### PR DESCRIPTION
## Summary
- unquote advertised addresses and reorder Qdrant port variables in `.env.example`
- refine ask_qdrant unit stubs to avoid blanket noqa usage and capture embeddings
- narrow lint suppression in kg_build tests and use pytest monkeypatch fixture

## Testing
- PYTHONPATH=src pytest tests/unit/scripts/test_ask_qdrant.py
- PYTHONPATH=stubs:src pytest tests/unit/scripts/test_kg_build.py

------
https://chatgpt.com/codex/tasks/task_e_68dca4437c6083229953e8cae4b4a7c5