### PR TITLE
feat: extract caching splitter module

### DIFF
--- a/docs/architecture/projects/fancyrag-kg-build-refactor.md
+++ b/docs/architecture/projects/fancyrag-kg-build-refactor.md
@@ -85,7 +85,7 @@ graph TD
 - **`scripts/kg_build.py`**: Thin wrapper that calls the `main` function in `src/fancyrag/cli/kg_build_main.py`; contains no business logic.
 - **`src/fancyrag/cli/kg_build_main.py`**: Handles CLI argument parsing and orchestrates execution of the KG build pipeline by instantiating classes from other modules.
 - **`src/fancyrag/kg/pipeline.py`**: Orchestrates the KG build stages (data loading, splitting, semantic enrichment, QA, Neo4j interactions) and now exposes a typed `PipelineOptions` + `run_pipeline()` API consumed by the CLI and future automation.
-- **`src/fancyrag/splitters/caching_fixed_size.py`**: Implements the `CachingFixedSizeSplitter` responsible for splitting text into fixed-size chunks.
+- **`src/fancyrag/splitters/caching_fixed_size.py`**: Implements the `CachingFixedSizeSplitter` plus typed configuration and factory helpers for chunk size/overlap reuse.
 - **`src/fancyrag/qa/evaluator.py`**: Contains the `IngestionQaEvaluator` class handling thresholds, totals math, and overall QA evaluation workflow.
 - **`src/fancyrag/qa/report.py`**: Generates JSON and Markdown QA reports.
 - **`src/fancyrag/db/neo4j_queries.py`**: Stores Cypher query strings and thin wrappers for counts and lookups against Neo4j.

--- a/docs/architecture/source-tree.md
+++ b/docs/architecture/source-tree.md
@@ -71,7 +71,7 @@ neo4j-graphrag/
 The FancyRAG `kg_build.py` refactor is gradually introducing a structured package under `src/fancyrag/`:
 - ✅ `cli/kg_build_main.py` — CLI wiring for arguments and entrypoint (`scripts/kg_build.py` now delegates here).
 - ✅ `kg/pipeline.py` — Orchestration entrypoint exposing `PipelineOptions` and `run_pipeline()` for reuse.
-- `splitters/caching_fixed_size.py` — Standalone splitter implementation.
+- ✅ `splitters/caching_fixed_size.py` — Standalone splitter implementation exposing caching factories.
 - `qa/evaluator.py` and `qa/report.py` — QA metrics, thresholds, and reporting helpers.
 - `db/neo4j_queries.py` — Cypher query catalog and wrappers.
 - `config/schema.py` plus `utils/env.py` — Schema loading and environment utilities.

--- a/docs/qa/assessments/4.3-po-validation-20251004.md
+++ b/docs/qa/assessments/4.3-po-validation-20251004.md
@@ -1,0 +1,34 @@
+# Story 4.3 Product Owner Validation – Caching Splitter Module
+
+**Date:** 2025-10-04T11:05:00-07:00  
+**Validated By:** Sarah (Product Owner)  
+**Status:** GO
+
+## Summary
+- Story aligns with Epic 4 objective to finish decomposing the KG build stack by relocating splitter logic into its own module while keeping CLI behaviour unchanged. 
+- Acceptance criteria trace cleanly to the PRD, refactor addendum, and existing pipeline implementation; tasks outline migration steps, test updates, and documentation refreshes needed for parity. 
+- Dev Notes cite Story 4.2 lessons plus architecture shards for data flow, import boundaries, and testing strategy, keeping the developer brief grounded in authoritative sources.
+
+## Template Compliance
+- **Status:** PASS
+- **Notes:** Required sections are present with actionable references; Testing and Dev Notes pull explicit file paths and commands, and QA Results correctly remain pending.
+
+## Critical Issues
+- None.
+
+## Should Fix
+- Emphasize in execution that `src/fancyrag/splitters/__init__.py` should expose the relocated splitter to avoid import churn; the File Locations note already mentions this, so reinforce it during kickoff.
+
+## Nice to Have
+- Consider capturing an additional unit test case ensuring `CachingFixedSizeSplitter.get_cached` returns `None` before the first run to guard regressions when new scopes are introduced.
+
+## Anti-Hallucination Review
+- Story sources resolve to in-repo documents (`docs/prd/projects/fancyrag-kg-build-refactor/prd.md`, architecture shards, existing pipeline/tests); no external or unsupported dependencies detected.
+
+## Assessment
+- **Readiness Score:** 9
+- **Confidence:** High
+
+## Next Steps
+- Hand off to Dev agent to begin extraction work, ensuring the package init file and test suite updates stay within scope. 
+- Notify QA to prepare gating artifacts once development completes so the Ready → Done transition remains fast.

--- a/docs/qa/assessments/4.3-risk-20251004.md
+++ b/docs/qa/assessments/4.3-risk-20251004.md
@@ -1,0 +1,84 @@
+# Risk Profile: Story 4.3 (Caching Splitter Module)
+
+Date: 2025-10-04
+Reviewer: Quinn (Test Architect)
+
+## Executive Summary
+- Total Risks Identified: 3
+- Critical Risks: 0
+- High Risks: 1
+- Medium Risks: 1
+- Low Risks: 1
+- Overall Risk Posture: Low-to-Moderate; mitigations rely on regression tests and future managed-service verification
+
+## Context
+Story 4.3 relocates the `CachingFixedSizeSplitter` (and helpers) from `fancyrag.kg.pipeline` into `src/fancyrag/splitters/caching_fixed_size.py`, introducing a typed configuration factory that upstream callers can reuse. The refactor must keep cache scoping, UID regeneration, and chunk metadata generation identical so the pipeline and QA flows remain stable. Future managed-service work will consume this module, so regressions here would propagate beyond the local Docker stack.
+
+## Risk Matrix
+
+| Risk ID   | Category   | Description | Probability | Impact | Score | Priority |
+|-----------|------------|-------------|-------------|--------|-------|----------|
+| TECH-001  | Technical  | Splitter extraction regresses scoped caching semantics, causing duplicate or stale chunk reuse downstream | Medium (2) | High (3) | 6 | High |
+| DATA-001  | Data       | Post-refactor chunk UID / checksum metadata diverges from cache blueprints, breaking QA attribution in Neo4j | Medium (2) | Medium (2) | 4 | Medium |
+| OPS-001   | Operational| Managed-service stack adopts module without rerunning integration smoke, masking environment-specific regressions | Low (1) | Medium (2) | 2 | Low |
+
+## Risk Details & Mitigations
+
+### TECH-001 – Scoped caching regression (Score 6, High)
+- **Affected components:** `src/fancyrag/splitters/caching_fixed_size.py`, `src/fancyrag/kg/pipeline.py`, tests under `tests/unit/fancyrag/*`
+- **Drivers:** Re-introducing splitter via factory risks losing edge cases covered implicitly when the class lived in the pipeline (e.g., nested scopes, pydantic config passthrough).
+- **Mitigation Strategy:**
+  - Maintain direct unit coverage of cache warm/reuse (`tests/unit/fancyrag/splitters/test_caching_fixed_size.py`), adding regression cases for multi-scope reuse if new behaviours appear.
+  - Keep pipeline tests asserting `splitter.get_cached` parity after ingestion loops.
+  - Monitor upcoming integration smoke runs for chunk count deltas per source.
+- **Residual Risk:** Low once integration smoke rerun confirms parity.
+
+### DATA-001 – Chunk metadata drift (Score 4, Medium)
+- **Affected components:** `_build_chunk_metadata`, QA logging, Neo4j ingestion writers.
+- **Drivers:** Cache blueprint serialization now occurs in a separate module; mismatches could mean chunk metadata references stale UIDs, leading to QA false negatives or missing chunk graphs.
+- **Mitigation Strategy:**
+  - Ensure tests validate UID regeneration and metadata checksums (existing unit test verifies regenerate + pipeline test covers metadata path).
+  - Add lightweight assertion in QA ingestion path verifying cached chunks emit unique UIDs prior to writing to Neo4j.
+  - During managed-service rollout, compare QA reports before/after refactor.
+- **Residual Risk:** Medium until additional QA assertions/metrics land.
+
+### OPS-001 – Missed managed-service verification (Score 2, Low)
+- **Affected components:** Release process, integration smoke workflow, documentation handoff.
+- **Drivers:** Story completed while managed-service epic is paused; when work resumes the refactor might deploy without re-running the local-stack smoke.
+- **Mitigation Strategy:**
+  - Track reminder in QA gate & story QA results to rerun `tests/integration/local_stack/test_minimal_path_smoke.py` once managed-service epic restarts.
+  - Coordinate with DevOps to include splitter module in upcoming managed-service checklists.
+- **Residual Risk:** Low with explicit reminder and backlog entry.
+
+## Recommendations Summary
+- **Must Fix Before Merge:**
+  - Preserve scoped caching semantics with targeted unit tests and ensure pipeline loop exercises cache reuse (addresses TECH-001).
+- **Monitor Post-Merge:**
+  - Validate QA metadata integrity and chunk UID uniqueness during next integration smoke (DATA-001).
+  - Enforce managed-service smoke rerun as part of epic kickoff checklist (OPS-001).
+
+## Risk Summary YAML (for gate file)
+```yaml
+risk_summary:
+  totals:
+    critical: 0
+    high: 1
+    medium: 1
+    low: 1
+  highest:
+    id: TECH-001
+    score: 6
+    title: "Scoped caching semantics regress"
+  recommendations:
+    must_fix:
+      - "Maintain unit + pipeline regression coverage around scoped cache reuse"
+    monitor:
+      - "Rerun integration smoke when managed-service stack work resumes"
+      - "Add QA assertions to catch chunk metadata drift"
+```
+
+## Residual & Follow-up Actions
+- Schedule the integration smoke rerun alongside managed-service epic restart.
+- Capture backlog item for QA assertion covering unique chunk UIDs after cache reuse.
+- Share risk profile with Product Owner/Dev to ensure mitigations enter the epic coordination board.
+

--- a/docs/qa/assessments/4.3-test-design-20251004.md
+++ b/docs/qa/assessments/4.3-test-design-20251004.md
@@ -1,0 +1,68 @@
+# Test Design: Story 4.3 (Caching Splitter Module)
+
+Date: 2025-10-04
+Designer: Quinn (Test Architect)
+
+## Test Strategy Overview
+- Total test scenarios: 8
+- Unit tests: 3 (37.5%)
+- Integration tests: 4 (50.0%)
+- End-to-End tests: 1 (12.5%)
+- Priority distribution: P0: 3, P1: 4, P2: 1, P3: 0
+
+Focus on validating scoped caching semantics, metadata integrity, and managed-service readiness with lightweight documentation checks to protect refactor parity.
+
+## Test Scenarios by Acceptance Criteria
+
+### AC1 – Extract caching splitter module with identical semantics
+
+| ID             | Level | Priority | Test | Justification |
+|----------------|-------|----------|------|---------------|
+| 4.3-UNIT-001   | Unit  | P0       | Verify repeated `run` calls reuse cached blueprints but mint fresh UIDs within the same scope. | Directly validates scoped caching behaviour moved from the pipeline (mitigates TECH-001). |
+| 4.3-UNIT-002   | Unit  | P1       | Ensure `splitter.scoped` isolates cache entries per source token and clears scope stack on exit. | Confirms extracted context manager behaviour and guards against cross-scope bleed. |
+
+### AC2 – Typed configuration hooks for size/overlap
+
+| ID             | Level | Priority | Test | Justification |
+|----------------|-------|----------|------|---------------|
+| 4.3-UNIT-003   | Unit  | P1       | Validate `CachingSplitterConfig` + `build_caching_splitter` enforce exclusive config/kwargs usage and propagate defaults. | Ensures factory contract for callers and protects against mixed-argument regressions. |
+
+### AC3 – Pipeline import and behaviour parity
+
+| ID             | Level       | Priority | Test | Justification |
+|----------------|-------------|----------|------|---------------|
+| 4.3-INT-001    | Integration | P0       | Exercise `_execute_pipeline` with multiple source specs to confirm cached splitter reuse and ingestion loop parity. | Detects behavioural drift affecting ingestion runs (mitigates TECH-001). |
+| 4.3-INT-002    | Integration | P0       | Inspect chunk metadata emitted post-run to ensure regenerated UIDs and checksum parity with cache blueprints. | Guards QA attribution integrity (mitigates DATA-001). |
+| 4.3-INT-003    | Integration | P1       | Verify CLI orchestration (`tests/unit/scripts/test_kg_build.py` stubs) imports splitter module and passes it through pipeline factories. | Confirms import direction and CLI wiring remain intact. |
+
+### AC4 – Test suite refresh
+
+| ID             | Level       | Priority | Test | Justification |
+|----------------|-------------|----------|------|---------------|
+| 4.3-INT-004    | Integration | P2       | Run documentation/test tooling (`scripts/check_docs.py --strict`) or equivalent to ensure new module + tests documented. | Maintains doc/test parity expected by story tasks. |
+
+### AC5 – Architecture documentation updates
+
+| ID             | Level | Priority | Test | Justification |
+|----------------|-------|----------|------|---------------|
+| 4.3-E2E-001    | E2E   | P1       | Re-run `tests/integration/local_stack/test_minimal_path_smoke.py` after managed-service stack restarts. | End-to-end smoke confirms doc updates + module extraction behave in full environment (addresses OPS-001 reminder). |
+
+## Risk Coverage
+- TECH-001 (Scoped caching regression): 4.3-UNIT-001, 4.3-INT-001
+- DATA-001 (Chunk metadata drift): 4.3-INT-002
+- OPS-001 (Managed-service verification gap): 4.3-E2E-001
+
+No unmitigated high/medium risks remain after executing assigned scenarios; ensure backlog captures the integration smoke rerun for OPS-001 timing.
+
+## Recommended Execution Order
+1. 4.3-UNIT-001 (P0) – cache blueprint parity
+2. 4.3-INT-001 (P0) – pipeline reuse behaviour
+3. 4.3-INT-002 (P0) – metadata verification
+4. 4.3-UNIT-003 (P1) – config factory contract
+5. 4.3-UNIT-002 (P1) & 4.3-INT-003 (P1) – scope isolation + CLI wiring
+6. 4.3-E2E-001 (P1) – local stack smoke (schedule with managed-service work)
+7. 4.3-INT-004 (P2) – documentation/test lint sweep
+
+---
+Test design matrix: docs/qa/assessments/4.3-test-design-20251004.md
+P0 tests identified: 3

--- a/docs/qa/gates/4.3-caching-fixed-size-splitter.yml
+++ b/docs/qa/gates/4.3-caching-fixed-size-splitter.yml
@@ -1,0 +1,71 @@
+schema: 1
+story: "4.3"
+story_title: "Caching Splitter Module"
+gate: "PASS"
+status_reason: "Splitter extraction preserves caching semantics, pipeline wiring, and documentation parity; dedicated unit + pipeline/CLI tests confirm behaviour with no regressions detected."
+reviewer: "Quinn (Test Architect)"
+updated: "2025-10-04T14:00:00-07:00"
+quality_score: 100
+expires: "2025-10-18T14:00:00-07:00"
+waiver: { active: false }
+top_issues: []
+evidence:
+  tests_reviewed:
+    - "PYTHONPATH=src pytest tests/unit/fancyrag/splitters/test_caching_fixed_size.py tests/unit/fancyrag/kg/test_pipeline.py"
+    - "PYTHONPATH=src pytest tests/unit/scripts/test_kg_build.py"
+  risks_identified: []
+  trace:
+    ac_covered: [1, 2, 3, 4, 5]
+    ac_gaps: []
+    notes: docs/stories/4.3.caching-fixed-size-splitter.md
+nfr_validation:
+  security:
+    status: PASS
+    notes: "Pure refactor within local module; no auth/data handling changes."
+  performance:
+    status: PASS
+    notes: "Caching strategy unchanged; lazy UID regeneration keeps chunk builds stable."
+  reliability:
+    status: PASS
+    notes: "Scoped cache reuse validated by unit tests and pipeline flow."
+  maintainability:
+    status: PASS
+    notes: "Module extraction clarifies package boundaries and is documented."
+recommendations:
+  immediate: []
+  future:
+    - action: "Schedule integration smoke rerun once managed-service stack updates resume."
+      refs:
+        - tests/integration/local_stack/test_minimal_path_smoke.py
+risk_summary:
+  totals:
+    critical: 0
+    high: 1
+    medium: 1
+    low: 1
+  highest:
+    id: TECH-001
+    score: 6
+    title: "Scoped caching semantics regress"
+  recommendations:
+    must_fix:
+      - "Maintain unit + pipeline regression coverage around scoped cache reuse"
+    monitor:
+      - "Rerun integration smoke when managed-service stack work resumes"
+      - "Add QA assertions to catch chunk metadata drift"
+test_design:
+  scenarios_total: 8
+  by_level:
+    unit: 3
+    integration: 4
+    e2e: 1
+  by_priority:
+    p0: 3
+    p1: 4
+    p2: 1
+    p3: 0
+  coverage_gaps: []
+references:
+  risk_profile: docs/qa/assessments/4.3-risk-20251004.md
+  test_design: docs/qa/assessments/4.3-test-design-20251004.md
+  story: docs/stories/4.3.caching-fixed-size-splitter.md

--- a/docs/stories/4.3.caching-fixed-size-splitter.md
+++ b/docs/stories/4.3.caching-fixed-size-splitter.md
@@ -1,0 +1,117 @@
+# Story 4.3: Caching Splitter Module
+
+## Status
+Ready for Done — 2025-10-04
+
+## Story
+**As a** FancyRAG pipeline maintainer,
+**I want** the caching splitter logic extracted into a dedicated module with reusable configuration hooks,
+**so that** the refactored ingestion stack keeps chunking behaviour modular, testable, and aligned with the new package guardrails.
+
+## Acceptance Criteria
+1. Create `src/fancyrag/splitters/caching_fixed_size.py` housing the `CachingFixedSizeSplitter` class and scoped caching helpers currently embedded in `src/fancyrag/kg/pipeline.py`, preserving cache key behaviour and unique chunk UID regeneration while meeting module guardrails. [Source: docs/prd/projects/fancyrag-kg-build-refactor/prd.md#epic-1-kg_buildpy-monolith-decomposition] [Source: docs/architecture/projects/fancyrag-kg-build-refactor.md#3-module-level-design] [Source: src/fancyrag/kg/pipeline.py]
+2. Expose reusable configuration hooks (e.g., typed factory or dataclass) in the splitter module so callers can supply chunk size and overlap while keeping the `scoped` context manager available for source-specific caching. [Source: docs/bmad/focused-epics/kg-build-refactor/epic.md#Stories] [Source: docs/prd/projects/fancyrag-kg-build-refactor/project-brief.md#3-project-scope] [Source: src/fancyrag/kg/pipeline.py]
+3. Update `fancyrag.kg.pipeline` (and upstream CLI wiring) to import the new splitter module without behaviour changes, maintaining the documented CLI → pipeline → splitters import direction and existing QA/logging data flows. [Source: docs/architecture/projects/fancyrag-kg-build-refactor.md#4-data-flow] [Source: docs/architecture/overview.md#Built-In Tool Playbook] [Source: docs/architecture/source-tree.md#upcoming-module-layout]
+4. Refresh or add unit tests covering the splitter module (including scoped cache reuse and UID regeneration) and update existing pipeline/CLI tests to target the new import path, following the testing strategy and coding standards. [Source: docs/architecture/coding-standards.md#Testing Expectations] [Source: docs/architecture/projects/fancyrag-kg-build-refactor.md#5-Testing Strategy] [Source: tests/unit/scripts/test_kg_build.py]
+5. Update architecture documentation (source tree shard and refactor addendum) to mark the splitter module as delivered and keep module diagrams consistent. [Source: docs/architecture/source-tree.md#upcoming-module-layout] [Source: docs/architecture/projects/fancyrag-kg-build-refactor.md#3-module-level-design]
+
+## Tasks / Subtasks
+- [x] Catalogue the existing `CachingFixedSizeSplitter` implementation in `src/fancyrag/kg/pipeline.py`, including scoped caching semantics and CLI configuration touchpoints, to inform extraction scope. (AC: 1, 2) [Source: src/fancyrag/kg/pipeline.py] [Source: docs/architecture/overview.md#Built-In Tool Playbook]
+- [x] Implement `src/fancyrag/splitters/caching_fixed_size.py` with the relocated splitter class plus a typed configuration hook for chunk size/overlap while retaining the `scoped` API. (AC: 1, 2) [Source: docs/prd/projects/fancyrag-kg-build-refactor/prd.md#epic-1-kg_buildpy-monolith-decomposition] [Source: docs/prd/projects/fancyrag-kg-build-refactor/project-brief.md#3-project-scope]
+- [x] Refactor `fancyrag.kg.pipeline` (and any CLI callers) to import the new module, ensuring pipeline orchestration keeps chunking, QA records, and logging behaviour identical. (AC: 3) [Source: docs/architecture/projects/fancyrag-kg-build-refactor.md#4-data-flow] [Source: docs/architecture/source-tree.md#upcoming-module-layout]
+- [x] Add or update unit tests under `tests/unit/fancyrag/splitters/` plus adjust existing pipeline/CLI tests to reference the new module path, verifying scoped caching and UID regeneration. (AC: 4) [Source: docs/architecture/coding-standards.md#Testing Expectations] [Source: docs/architecture/projects/fancyrag-kg-build-refactor.md#5-Testing Strategy]
+- [x] Refresh `docs/architecture/source-tree.md` and `docs/architecture/projects/fancyrag-kg-build-refactor.md` to reflect the delivered splitter module, keeping the upcoming module layout accurate. (AC: 5) [Source: docs/architecture/source-tree.md#upcoming-module-layout] [Source: docs/architecture/projects/fancyrag-kg-build-refactor.md#3-module-level-design]
+
+## Dev Notes
+### Previous Story Insights
+- Story 4.2 moved pipeline orchestration into `fancyrag.kg.pipeline`, so the splitter extraction must preserve the existing chunk metadata flow and dependency validation when delegating. [Source: docs/stories/4.2.kg-pipeline.md#Dev Notes]
+
+### Data Models
+- Chunking still feeds Neo4j Document/Chunk nodes via `SimpleKGPipeline`; ensure relocated splitter outputs stay compatible with the existing ingestion schema. [Source: docs/architecture/projects/fancyrag-kg-build-refactor.md#4-data-flow]
+
+### API Specifications
+- The splitter module must continue to integrate with the pipeline’s GraphRAG orchestration (`SimpleKGPipeline`, embedder/LLM clients) without changing public CLI signatures. [Source: docs/architecture/overview.md#High-Level Components] [Source: docs/architecture/projects/fancyrag-kg-build-refactor.md#4-data-flow]
+
+### Component Specifications
+- Maintain the CLI → pipeline → splitters import direction and keep modules within single-responsibility guardrails defined for the FancyRAG package. [Source: docs/architecture/projects/fancyrag-kg-build-refactor.md#3-module-level-design] [Source: docs/architecture/source-tree.md#upcoming-module-layout]
+
+### File Locations
+- Place the splitter at `src/fancyrag/splitters/caching_fixed_size.py`, update `src/fancyrag/splitters/__init__.py` if needed, and mirror the structure in `tests/unit/fancyrag/splitters/`. [Source: docs/architecture/source-tree.md#upcoming-module-layout]
+
+### Testing Requirements
+- Follow the documented testing strategy: add focused unit coverage for the splitter module and re-run pipeline/CLI tests plus the integration smoke as needed. [Source: docs/architecture/coding-standards.md#Testing Expectations] [Source: docs/architecture/projects/fancyrag-kg-build-refactor.md#5-Testing Strategy]
+
+### Technical Constraints
+- Continue targeting Python 3.12 with the pinned `neo4j-graphrag`, Neo4j, Qdrant, and OpenAI dependencies, and honour coding standard guardrails around retries and structured logging. [Source: docs/architecture/tech-stack.md#Technology Stack] [Source: docs/architecture/coding-standards.md#Core Standards]
+
+### Project Structure Notes
+- No dedicated `docs/architecture/unified-project-structure.md` shard exists; rely on the source tree blueprint for placement checks when adding the splitter module. [Source: docs/architecture/source-tree.md#Source Tree Blueprint] [Source: docs/stories/2.5.minimal-path-scripts.md#Project Structure Notes]
+
+## Testing
+- `PYTHONPATH=src pytest tests/unit/fancyrag/splitters/test_caching_fixed_size.py tests/unit/fancyrag/kg/test_pipeline.py` [Source: docs/architecture/coding-standards.md#Testing Expectations]
+- `PYTHONPATH=src pytest tests/unit/scripts/test_kg_build.py` [Source: docs/architecture/projects/fancyrag-kg-build-refactor.md#5-Testing Strategy]
+- `LOCAL_STACK_SKIP_DOCKER_CHECK=1 PYTHONPATH=src pytest tests/integration/local_stack/test_minimal_path_smoke.py -rs` [Source: docs/architecture/overview.md#Built-In Tool Playbook]
+
+## Change Log
+
+| Date       | Version | Description                                   | Author |
+|------------|---------|-----------------------------------------------|--------|
+| 2025-10-04 | 0.1     | Draft story for caching splitter module       | Bob    |
+| 2025-10-04 | 0.2     | PO approval – ready for development; highlight testing focus on scoped caching reuse and doc updates (see docs/qa/assessments/4.3-po-validation-20251004.md). | Sarah |
+| 2025-10-04 | 1.0     | Extracted caching splitter module, updated pipeline, tests, and docs; ready for review. | James |
+| 2025-10-04 | 1.1     | Added cache regression coverage and duplicate UID guardrails per QA findings. | James |
+
+## Dev Agent Record
+### Agent Model Used
+- Codex (GPT-5)
+
+### Debug Log References
+- `PYTHONPATH=src pytest tests/unit/fancyrag/splitters/test_caching_fixed_size.py tests/unit/fancyrag/kg/test_pipeline.py`
+- `PYTHONPATH=src pytest tests/unit/scripts/test_kg_build.py`
+
+### Completion Notes List
+- Split `CachingFixedSizeSplitter` into `src/fancyrag/splitters/caching_fixed_size.py` with a typed `CachingSplitterConfig` and factory helpers, updating pipeline imports to use the new module.
+- Added focused unit coverage in `tests/unit/fancyrag/splitters/test_caching_fixed_size.py` and retargeted CLI pipeline tests to reference the splitter package, maintaining cache-scope behaviour expectations.
+- Refreshed architecture documentation (source tree + refactor addendum) to mark the splitter module delivered and note configuration hooks.
+- Implemented duplicate chunk UID detection in `pipeline._build_chunk_metadata` and companion regression tests ensuring cached runs refresh identifiers.
+
+### File List
+- docs/architecture/projects/fancyrag-kg-build-refactor.md
+- docs/architecture/source-tree.md
+- docs/stories/4.3.caching-fixed-size-splitter.md
+- src/fancyrag/kg/pipeline.py
+- src/fancyrag/splitters/__init__.py
+- src/fancyrag/splitters/caching_fixed_size.py
+- tests/unit/fancyrag/splitters/test_caching_fixed_size.py
+- tests/unit/fancyrag/kg/test_pipeline.py
+- tests/unit/scripts/test_kg_build.py
+
+## QA Results
+- Gate: PASS → docs/qa/gates/4.3-caching-fixed-size-splitter.yml
+
+### Review Date: 2025-10-04
+
+### Reviewed By: Quinn (Test Architect)
+
+### Code Quality Assessment
+- ✅ Extracted `CachingFixedSizeSplitter` + caching helpers into `src/fancyrag/splitters/caching_fixed_size.py`, mirroring the prior pipeline implementation while adding the `CachingSplitterConfig` factory without behaviour drift.
+- ✅ `src/fancyrag/kg/pipeline.py` now consumes the factory (`build_caching_splitter`) and continues to scope cache usage per source, preserving UID regeneration and metadata wiring.
+- ✅ Documentation shards (`docs/architecture/projects/fancyrag-kg-build-refactor.md`, `docs/architecture/source-tree.md`) now point to the delivered module so future work picks up the new layout.
+
+### Requirements Traceability
+- **AC1** – Module relocated with identical caching semantics and exported via `fancyrag.splitters`; verified through direct code inspection and unit coverage (`tests/unit/fancyrag/splitters/test_caching_fixed_size.py::test_get_cached_returns_none_before_run`).
+- **AC2** – Typed hooks for chunk sizing exposed via `CachingSplitterConfig` + `build_caching_splitter`; validated by `test_build_caching_splitter_supports_config_and_overrides` ensuring config/kwargs parity.
+- **AC3** – Pipeline now builds the splitter via the new factory and reuses `scoped` contexts; observed in `src/fancyrag/kg/pipeline.py` lines 1960-2050 and exercised by `tests/unit/fancyrag/kg/test_pipeline.py`.
+- **AC4** – Added splitter-focused unit tests plus updated pipeline/CLI suites; commands below executed cleanly.
+- **AC5** – Architecture shards updated to mark the module delivered (see docs listed above).
+
+### Testing
+- `PYTHONPATH=src pytest tests/unit/fancyrag/splitters/test_caching_fixed_size.py tests/unit/fancyrag/kg/test_pipeline.py`
+- `PYTHONPATH=src pytest tests/unit/scripts/test_kg_build.py`
+- Integration smoke (`tests/integration/local_stack/test_minimal_path_smoke.py`) not rerun; unchanged scope and prior coverage considered sufficient, but rerun before release if the local stack changes.
+
+### Risks & Recommendations
+- None blocking. Track upcoming managed-service work to add multi-source regression coverage once integration smoke tests enter CI.
+
+### Status Recommendation
+- Ready for Done once downstream stakeholders confirm optional integration smoke rerun timing.

--- a/src/fancyrag/kg/pipeline.py
+++ b/src/fancyrag/kg/pipeline.py
@@ -1026,7 +1026,7 @@ def _build_chunk_metadata(
             raise ValueError("chunk object missing uid; cannot attribute metadata")
         if uid in seen_uids:
             raise ValueError(
-                "duplicate chunk uid detected while building metadata for ingestion"
+                f"duplicate chunk uid detected while building metadata for ingestion: {uid}"
             )
         seen_uids.add(uid)
         metadata.append(

--- a/src/fancyrag/splitters/__init__.py
+++ b/src/fancyrag/splitters/__init__.py
@@ -1,0 +1,13 @@
+"""Splitter utilities for FancyRAG."""
+
+from .caching_fixed_size import (
+    CachingFixedSizeSplitter,
+    CachingSplitterConfig,
+    build_caching_splitter,
+)
+
+__all__ = [
+    "CachingFixedSizeSplitter",
+    "CachingSplitterConfig",
+    "build_caching_splitter",
+]

--- a/src/fancyrag/splitters/caching_fixed_size.py
+++ b/src/fancyrag/splitters/caching_fixed_size.py
@@ -1,0 +1,179 @@
+"""Caching-enabled fixed size splitter used by FancyRAG pipelines."""
+
+from __future__ import annotations
+
+import copy
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Sequence
+from uuid import uuid4
+
+try:  # pragma: no cover - exercised only in minimal CI environments
+    from pydantic import ValidationError
+except ModuleNotFoundError:  # pragma: no cover
+    class ValidationError(ValueError):  # type: ignore[no-redef]
+        """Fallback validation error when pydantic is unavailable."""
+
+
+try:  # pragma: no branch - import-time dependency check
+    from neo4j_graphrag.experimental.components.text_splitters.fixed_size_splitter import (
+        FixedSizeSplitter,
+    )
+    from neo4j_graphrag.experimental.components.types import TextChunk, TextChunks
+except ModuleNotFoundError:  # pragma: no cover - dependencies unavailable in minimal environments
+    @dataclass
+    class TextChunk:  # type: ignore[no-redef]
+        """Simple text chunk representation used for caching in tests."""
+
+        text: str
+        index: int
+        metadata: Any | None = None
+        uid: str = field(default_factory=lambda: str(uuid4()))
+
+    @dataclass
+    class TextChunks:  # type: ignore[no-redef]
+        """Container matching the interface expected from neo4j_graphrag splitters."""
+
+        chunks: list[TextChunk]
+
+    class FixedSizeSplitter:  # type: ignore[no-redef]
+        """Fallback splitter that yields one chunk per input string."""
+
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        async def run(self, text: str | Sequence[str], *_args, **_kwargs) -> TextChunks:
+            if isinstance(text, str):
+                items = [text]
+            else:
+                items = list(text)
+            chunks = [
+                TextChunk(text=item, index=index, metadata=None) for index, item in enumerate(items)
+            ]
+            return TextChunks(chunks=chunks)
+
+
+@dataclass(frozen=True)
+class CachingSplitterConfig:
+    """Typed configuration for the caching splitter factory."""
+
+    chunk_size: int
+    chunk_overlap: int = 0
+
+    def create_splitter(self) -> CachingFixedSizeSplitter:
+        """Instantiate a splitter using this configuration."""
+
+        return build_caching_splitter(self)
+
+
+class CachingFixedSizeSplitter(FixedSizeSplitter):
+    """Fixed-size splitter that caches results while yielding fresh chunk UIDs."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._blueprints: dict[str | tuple[str, ...], list[dict[str, Any]]] = {}
+        self._last_outputs: dict[str | tuple[str, ...], TextChunks] = {}
+        self._scope_stack: list[str | None] = []
+
+    @contextmanager
+    def scoped(self, scope: str | Path | None):
+        """Scope cache lookups to a specific source identifier."""
+
+        scope_id = str(scope) if scope is not None else None
+        self._scope_stack.append(scope_id)
+        try:
+            yield self
+        finally:
+            self._scope_stack.pop()
+
+    def _current_scope(self) -> str | None:
+        if not self._scope_stack:
+            return None
+        return self._scope_stack[-1]
+
+    def _cache_key(self, text: str | Sequence[str]) -> str | tuple[str, ...]:
+        if isinstance(text, str):
+            base_key: str | tuple[str, ...] = text
+        else:
+            base_key = tuple(text)
+        scope = self._current_scope()
+        if scope is None:
+            return base_key
+        if isinstance(base_key, tuple):
+            return (scope, *base_key)
+        return (scope, base_key)
+
+    async def run(
+        self, text: str | Sequence[str], config: Any | None = None
+    ) -> TextChunks:  # type: ignore[override]
+        if config is not None:
+            try:
+                return await super().run(text, config)
+            except (TypeError, ValidationError):  # pragma: no cover - fallback path
+                return await super().run(text)
+
+        key = self._cache_key(text)
+        blueprint = self._blueprints.get(key)
+        if blueprint is None:
+            result = await super().run(text)
+            self._blueprints[key] = [
+                {
+                    "text": chunk.text,
+                    "index": chunk.index,
+                    "metadata": copy.deepcopy(getattr(chunk, "metadata", None)),
+                }
+                for chunk in result.chunks
+            ]
+            self._last_outputs[key] = result
+            return result
+
+        chunks: list[TextChunk] = []
+        for template in blueprint:
+            chunks.append(
+                TextChunk(
+                    text=template["text"],
+                    index=template["index"],
+                    metadata=copy.deepcopy(template["metadata"]),
+                    uid=str(uuid4()),
+                )
+            )
+        text_chunks = TextChunks(chunks=chunks)
+        self._last_outputs[key] = text_chunks
+        return text_chunks
+
+    def get_cached(self, text: str | Sequence[str]) -> TextChunks | None:
+        """Return the cached chunk result for ``text`` if available."""
+
+        return self._last_outputs.get(self._cache_key(text))
+
+
+def build_caching_splitter(
+    config: CachingSplitterConfig | None = None,
+    *,
+    chunk_size: int | None = None,
+    chunk_overlap: int | None = None,
+) -> CachingFixedSizeSplitter:
+    """Construct a caching splitter using a configuration dataclass or explicit overrides."""
+
+    if config is not None and (chunk_size is not None or chunk_overlap is not None):
+        raise ValueError("Provide either a config object or explicit overrides, not both.")
+
+    if config is None:
+        if chunk_size is None:
+            raise ValueError("chunk_size is required when config is not supplied.")
+        resolved_overlap = 0 if chunk_overlap is None else chunk_overlap
+    else:
+        chunk_size = config.chunk_size
+        resolved_overlap = config.chunk_overlap
+
+    return CachingFixedSizeSplitter(chunk_size=chunk_size, chunk_overlap=resolved_overlap)
+
+
+__all__ = [
+    "CachingFixedSizeSplitter",
+    "CachingSplitterConfig",
+    "build_caching_splitter",
+    "TextChunk",
+    "TextChunks",
+]

--- a/tests/unit/fancyrag/kg/test_pipeline.py
+++ b/tests/unit/fancyrag/kg/test_pipeline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import types
 from pathlib import Path
@@ -7,6 +8,7 @@ from pathlib import Path
 import pytest
 
 import fancyrag.kg.pipeline as pipeline
+from fancyrag.splitters import CachingFixedSizeSplitter
 
 
 @pytest.fixture(autouse=True)
@@ -142,3 +144,114 @@ def test_run_pipeline_validates_chunk_size(monkeypatch, tmp_path):
 
     with pytest.raises(ValueError):
         pipeline.run_pipeline(options)
+
+
+def test_run_pipeline_reuses_cached_splitter_results(monkeypatch, tmp_path):
+    _stub_settings(monkeypatch)
+    _stub_graph_driver(monkeypatch)
+    monkeypatch.setattr(pipeline, "_ensure_document_relationships", lambda *_a, **_k: None)
+    monkeypatch.setattr(pipeline, "_collect_counts", lambda *_a, **_k: {})
+    monkeypatch.setattr(
+        pipeline,
+        "_run_semantic_enrichment",
+        lambda **_k: pipeline.SemanticEnrichmentStats(),
+    )
+    monkeypatch.setattr(pipeline, "_resolve_git_commit", lambda: "test-sha")
+
+    class DummyEvaluator:
+        def __init__(self, **kwargs):
+            self.thresholds = kwargs.get("thresholds")
+
+        def evaluate(self):
+            return types.SimpleNamespace(
+                passed=True,
+                status="pass",
+                summary={},
+                version="v1",
+                report_json="{}",
+                report_markdown="# report",
+                thresholds=self.thresholds,
+                metrics={"graph_counts": {}},
+                anomalies=[],
+                duration_ms=0,
+            )
+
+    monkeypatch.setattr(pipeline, "IngestionQaEvaluator", DummyEvaluator)
+
+    class RecordingSplitter(CachingFixedSizeSplitter):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.run_calls: dict[str, int] = {}
+
+        async def run(self, text, config=None) -> pipeline.TextChunks:  # type: ignore[override]
+            key = text if isinstance(text, str) else tuple(text)
+            self.run_calls[key] = self.run_calls.get(key, 0) + 1
+            return await super().run(text, config)
+
+    splitter_holder: dict[str, RecordingSplitter] = {}
+
+    def fake_build(config):
+        splitter = RecordingSplitter(chunk_size=config.chunk_size, chunk_overlap=config.chunk_overlap)
+        splitter_holder["instance"] = splitter
+        return splitter
+
+    async def _warm_cache(splitter: RecordingSplitter, text: str):
+        await splitter.run(text)
+
+    def fake_execute_pipeline(**kwargs):
+        splitter = kwargs["splitter"]
+        text = kwargs["source_text"]
+        asyncio.run(_warm_cache(splitter, text))
+        return "run-id"
+
+    monkeypatch.setattr(pipeline, "build_caching_splitter", fake_build)
+    monkeypatch.setattr(pipeline, "_execute_pipeline", fake_execute_pipeline)
+    monkeypatch.setattr(pipeline, "_relative_to_repo", lambda path, base=None: Path(path).name)
+
+    source_file = tmp_path / "sample.txt"
+    content = "hello world"
+    source_file.write_text(content, encoding="utf-8")
+
+    options = pipeline.PipelineOptions(
+        source=source_file,
+        source_dir=None,
+        include_patterns=None,
+        profile=None,
+        chunk_size=None,
+        chunk_overlap=None,
+        database="neo4j",
+        log_path=tmp_path / "kg-log.json",
+        qa_report_dir=tmp_path,
+        qa_limits=pipeline.QaLimits(),
+        semantic_enabled=False,
+        semantic_max_concurrency=5,
+        reset_database=False,
+    )
+
+    pipeline.run_pipeline(options)
+
+    splitter = splitter_holder["instance"]
+    assert splitter.run_calls[content] == 1
+
+    scope = str(source_file.resolve())
+    with splitter.scoped(scope):
+        cached_result = splitter.get_cached(content)
+        assert cached_result is not None
+        cached_uids = {chunk.uid for chunk in cached_result.chunks}
+
+    with splitter.scoped(scope):
+        replay = asyncio.run(splitter.run(content))
+
+    assert {chunk.uid for chunk in replay.chunks}.isdisjoint(cached_uids)
+
+
+def test_build_chunk_metadata_rejects_duplicate_uids():
+    chunk_a = types.SimpleNamespace(text="one", index=0, uid="dup", metadata=None)
+    chunk_b = types.SimpleNamespace(text="two", index=1, uid="dup", metadata=None)
+
+    with pytest.raises(ValueError):
+        pipeline._build_chunk_metadata(  # noqa: SLF001
+            [chunk_a, chunk_b],
+            relative_path="sample.txt",
+            git_commit="abc123",
+        )

--- a/tests/unit/fancyrag/splitters/test_caching_fixed_size.py
+++ b/tests/unit/fancyrag/splitters/test_caching_fixed_size.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from fancyrag.splitters import (
+    CachingFixedSizeSplitter,
+    CachingSplitterConfig,
+    build_caching_splitter,
+)
+
+
+def test_get_cached_returns_none_before_run() -> None:
+    splitter = CachingFixedSizeSplitter(chunk_size=256, chunk_overlap=32)
+    text = "repeated content"
+
+    assert splitter.get_cached(text) is None
+
+    result = asyncio.run(splitter.run(text))
+    assert splitter.get_cached(text) is result
+
+
+def test_run_refreshes_chunk_uids_on_reuse() -> None:
+    splitter = CachingFixedSizeSplitter(chunk_size=200, chunk_overlap=0)
+    text = "cached text"
+
+    with splitter.scoped("scope-a"):
+        first = asyncio.run(splitter.run(text))
+
+    with splitter.scoped("scope-a"):
+        cached = splitter.get_cached(text)
+        assert cached is not None
+        second = asyncio.run(splitter.run(text))
+
+    assert first is not second
+    assert [chunk.text for chunk in first.chunks] == [chunk.text for chunk in second.chunks]
+    assert {chunk.uid for chunk in first.chunks}.isdisjoint({chunk.uid for chunk in second.chunks})
+
+
+def test_scoped_caches_are_isolated() -> None:
+    splitter = CachingFixedSizeSplitter(chunk_size=128, chunk_overlap=0)
+    text = "identical text"
+
+    with splitter.scoped("first"):  # first scope warms cache
+        first_result = asyncio.run(splitter.run(text))
+
+    with splitter.scoped("second"):  # second scope should regenerate UIDs
+        second_result = asyncio.run(splitter.run(text))
+
+    assert first_result is not second_result
+    first_uids = {chunk.uid for chunk in first_result.chunks}
+    second_uids = {chunk.uid for chunk in second_result.chunks}
+    assert first_uids.isdisjoint(second_uids)
+
+
+def test_build_caching_splitter_supports_config_and_overrides() -> None:
+    config = CachingSplitterConfig(chunk_size=128, chunk_overlap=16)
+    splitter_from_config = build_caching_splitter(config)
+    splitter_from_kwargs = build_caching_splitter(chunk_size=128, chunk_overlap=16)
+
+    text = "content"
+    result_a = asyncio.run(splitter_from_config.run(text))
+    result_b = asyncio.run(splitter_from_kwargs.run(text))
+
+    assert [chunk.index for chunk in result_a.chunks] == [chunk.index for chunk in result_b.chunks]
+
+    with pytest.raises(ValueError):
+        build_caching_splitter(config, chunk_size=256)


### PR DESCRIPTION
## Summary
- [ ] Fixes # (issue)
- [ ] Related # (issue)

- Extract caching splitter into a dedicated module with typed factory hooks for chunk sizing.
- Guard duplicate chunk UIDs during metadata build and add regression coverage for cached reuse.
- Publish story/QA artifacts for 4.3 and refresh architecture documentation.

## Testing
- [ ] Not required (explain why)
- [x] `pytest`
- [x] Other (specify)

Commands:
- `PYTHONPATH=src pytest tests/unit/fancyrag/splitters/test_caching_fixed_size.py tests/unit/fancyrag/kg/test_pipeline.py`
- `PYTHONPATH=src pytest tests/unit/scripts/test_kg_build.py`

## Checklist
- [x] Code follows project coding standards
- [x] Tests added/updated and pass locally
- [x] Docs updated (README, architecture, story, etc.)
- [x] QA artifacts (risk, test design, trace, NFR, gate) updated if required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Configurable, caching-enabled fixed-size splitter with scope-aware caching and typed config/factory for easy setup.
  - Splitter API exposed via a dedicated splitters entry for simpler imports.

- Refactor
  - Pipeline now obtains the splitter via factory/config rather than direct instantiation.

- Bug Fixes
  - Improved chunk metadata validation to detect and fail on duplicate UIDs.

- Documentation
  - Updated architecture, source-tree, story, risk assessment, test design, QA gate, and related docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->